### PR TITLE
feat:add explore_page

### DIFF
--- a/assets/css/explore.css
+++ b/assets/css/explore.css
@@ -1,0 +1,140 @@
+/* ═══════════════════════════════════════════════
+   EXPLORE PAGE
+   ═══════════════════════════════════════════════ */
+
+.explore-header {
+  background: var(--paper);
+  padding: 2.5rem 0 2rem;
+  border-bottom: 1px solid var(--ink-200);
+}
+.explore-header h1 {
+  font-size: clamp(1.75rem, 3.5vw, 2.4rem);
+  margin-bottom: 0.5rem;
+}
+.explore-header p {
+  color: var(--ink-600);
+  font-size: 1rem;
+  margin-bottom: 1.5rem;
+  max-width: 600px;
+}
+
+/* ─── Search bar ─── */
+.explore-search-bar {
+  position: relative;
+  max-width: 520px;
+}
+.explore-search-bar i {
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--ink-400);
+  font-size: 1.1rem;
+  pointer-events: none;
+}
+.explore-search-bar input {
+  width: 100%;
+  padding: 0.85rem 1rem 0.85rem 2.75rem;
+  font-size: 1rem;
+  background: var(--paper);
+  border: 1.5px solid var(--ink-200);
+  border-radius: var(--radius-md);
+  transition: all var(--tr-fast);
+  font-family: var(--font-body);
+}
+.explore-search-bar input:focus {
+  outline: none;
+  border-color: var(--brand-primary);
+  box-shadow: 0 0 0 4px var(--brand-primary-light);
+}
+
+/* ─── Filter bar ─── */
+.filter-bar {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+  box-shadow: var(--shadow-sm);
+}
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 140px;
+  flex: 1;
+}
+.filter-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--ink-600);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.filter-select {
+  padding: 0.55rem 0.85rem;
+  font-size: 0.92rem;
+  background: var(--paper);
+  border: 1.5px solid var(--ink-200);
+  border-radius: var(--radius-md);
+  font-family: var(--font-body);
+  color: var(--ink-800);
+  cursor: pointer;
+  transition: border-color var(--tr-fast);
+}
+.filter-select:focus {
+  outline: none;
+  border-color: var(--brand-primary);
+  box-shadow: 0 0 0 4px var(--brand-primary-light);
+}
+.reset-btn {
+  flex-shrink: 0;
+  height: 42px;
+  align-self: flex-end;
+}
+
+.results-count {
+  margin-top: 1.25rem;
+  font-size: 0.92rem;
+  color: var(--ink-600);
+}
+.results-count strong { color: var(--ink-900); }
+
+/* ─── Empty state ─── */
+.empty-state {
+  text-align: center;
+  padding: 4rem 2rem;
+  background: var(--paper);
+  border: 2px dashed var(--ink-200);
+  border-radius: var(--radius-lg);
+  margin-top: 2rem;
+}
+.empty-icon {
+  width: 72px; height: 72px;
+  border-radius: 50%;
+  background: var(--ink-100);
+  color: var(--ink-400);
+  font-size: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+.empty-state h3 {
+  margin-bottom: 0.5rem;
+}
+.empty-state p {
+  color: var(--ink-600);
+  margin-bottom: 1.25rem;
+}
+
+.idea-item.hide { display: none !important; }
+
+@media (max-width: 767px) {
+  .filter-bar { flex-direction: column; align-items: stretch; }
+  .filter-group { min-width: 0; }
+  .reset-btn { align-self: stretch; }
+}

--- a/assets/js/explore.js
+++ b/assets/js/explore.js
@@ -1,0 +1,97 @@
+/* ═══════════════════════════════════════════════
+   EXPLORE JS — search + filter + sort
+   ═══════════════════════════════════════════════ */
+
+document.addEventListener('DOMContentLoaded', () => {
+
+  const searchInput = document.getElementById('searchInput');
+  const categorySelect = document.getElementById('filterCategory');
+  const stageSelect = document.getElementById('filterStage');
+  const sortSelect = document.getElementById('filterSort');
+  const resetBtn = document.getElementById('resetFilters');
+  const grid = document.getElementById('ideaGrid');
+  const countEl = document.getElementById('resultsCount');
+  const emptyState = document.getElementById('emptyState');
+  const allItems = Array.from(document.querySelectorAll('.idea-item'));
+
+  /* ─── Read URL ?q= on load ─── */
+  const urlParams = new URLSearchParams(window.location.search);
+  const qParam = urlParams.get('q');
+  if (qParam) {
+    searchInput.value = qParam;
+  }
+
+  /* ─── Apply filters ─── */
+  function applyFilters() {
+    const q = (searchInput.value || '').trim().toLowerCase();
+    const category = categorySelect.value;
+    const stage = stageSelect.value;
+
+    let visibleCount = 0;
+
+    allItems.forEach(item => {
+      const matchesQuery = !q ||
+        item.dataset.title.toLowerCase().includes(q) ||
+        item.dataset.category.toLowerCase().includes(q);
+      const matchesCategory = category === 'all' || item.dataset.category === category;
+      const matchesStage = stage === 'all' || item.dataset.stage === stage;
+
+      if (matchesQuery && matchesCategory && matchesStage) {
+        item.classList.remove('hide');
+        visibleCount++;
+      } else {
+        item.classList.add('hide');
+      }
+    });
+
+    countEl.textContent = visibleCount;
+    emptyState.style.display = visibleCount === 0 ? 'block' : 'none';
+    grid.style.display = visibleCount === 0 ? 'none' : '';
+  }
+
+  /* ─── Apply sort (just re-orders DOM nodes in grid) ─── */
+  function applySort() {
+    const sort = sortSelect.value;
+    const visibleItems = allItems.filter(i => !i.classList.contains('hide'));
+
+    const getVotes = (item) => {
+      const voteStrong = item.querySelector('.meta-item strong');
+      return voteStrong ? parseInt(voteStrong.textContent.replace(/,/g, ''), 10) : 0;
+    };
+
+    const getDate = (item) => {
+      // Parse "X days ago" / "X week ago" / etc. — rough sort weights
+      const text = (item.querySelector('.text-muted-iih')?.textContent || '').toLowerCase();
+      if (text.includes('days')) return parseInt(text, 10) || 1;
+      if (text.includes('week'))  return (parseInt(text, 10) || 1) * 7;
+      if (text.includes('month')) return (parseInt(text, 10) || 1) * 30;
+      return 999;
+    };
+
+    if (sort === 'votes') {
+      visibleItems.sort((a, b) => getVotes(b) - getVotes(a));
+    } else if (sort === 'newest') {
+      visibleItems.sort((a, b) => getDate(a) - getDate(b));
+    }
+    // 'trending' is the default order — leave alone
+
+    visibleItems.forEach(item => grid.appendChild(item));
+  }
+
+  /* ─── Event bindings ─── */
+  searchInput.addEventListener('input', applyFilters);
+  categorySelect.addEventListener('change', applyFilters);
+  stageSelect.addEventListener('change', applyFilters);
+  sortSelect.addEventListener('change', () => { applyFilters(); applySort(); });
+
+  resetBtn.addEventListener('click', () => {
+    searchInput.value = '';
+    categorySelect.value = 'all';
+    stageSelect.value = 'all';
+    sortSelect.value = 'trending';
+    applyFilters();
+  });
+
+  /* ─── Run once on load if ?q= was provided ─── */
+  if (qParam) applyFilters();
+});

--- a/templates/explore.html
+++ b/templates/explore.html
@@ -1,0 +1,418 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Explore ideas — Idea Incubator Hub</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="../assets/css/main.css">
+  <link rel="stylesheet" href="../assets/css/landing.css">
+  <link rel="stylesheet" href="../assets/css/explore.css">
+</head>
+<body data-page="explore">
+
+  <!-- NAVBAR -->
+  <nav class="navbar navbar-iih navbar-expand-lg">
+    <div class="container-iih w-100 d-flex align-items-center justify-content-between">
+      <a class="navbar-brand" href="index.html">
+        <span class="brand-mark"><i class="bi bi-lightbulb-fill"></i></span>
+        <span>Idea Incubator</span>
+      </a>
+      <button class="navbar-toggler border-0" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav">
+        <i class="bi bi-list fs-3"></i>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav mx-auto mb-2 mb-lg-0">
+          <li class="nav-item"><a class="nav-link" href="explore.html" data-page="explore">Explore</a></li>
+          <li class="nav-item"><a class="nav-link" href="dashboard.html" data-page="dashboard">Dashboard</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html" data-page="about">About</a></li>
+        </ul>
+        <div class="d-flex align-items-center gap-3">
+          <a href="submit-idea.html" class="btn btn-brand"><i class="bi bi-plus-lg"></i> New idea</a>
+          <div class="position-relative">
+            <div class="navbar-avatar avatar-1">JL</div>
+            <div class="avatar-dropdown">
+              <div class="menu-head"><div class="name">Jamie Liu</div><div class="email">jamie@example.com</div></div>
+              <a href="profile.html"><i class="bi bi-person"></i> My profile</a>
+              <a href="dashboard.html"><i class="bi bi-speedometer2"></i> Dashboard</a>
+              <hr><a href="login.html"><i class="bi bi-box-arrow-right"></i> Log out</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- ═══════════ HEADER ═══════════ -->
+  <section class="explore-header">
+    <div class="container-iih">
+      <h1 class="fade-up">Explore ideas</h1>
+      <p class="fade-up stagger-1">Browse ideas from the community. Vote on the ones you love, comment with your take.</p>
+
+      <!-- Search bar -->
+      <div class="explore-search-bar fade-up stagger-2">
+        <i class="bi bi-search"></i>
+        <input type="text" id="searchInput" placeholder="Search by title, category, or keyword…">
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════ FILTERS ═══════════ -->
+  <section class="container-iih mt-4">
+    <div class="filter-bar">
+      <div class="filter-group">
+        <label class="filter-label">Category</label>
+        <select class="filter-select" id="filterCategory">
+          <option value="all">All categories</option>
+          <option>FinTech</option>
+          <option>EdTech</option>
+          <option>GreenTech</option>
+          <option>Health</option>
+          <option>DevTools</option>
+          <option>Productivity</option>
+          <option>Social</option>
+        </select>
+      </div>
+      <div class="filter-group">
+        <label class="filter-label">Stage</label>
+        <select class="filter-select" id="filterStage">
+          <option value="all">Any stage</option>
+          <option value="ideation">Ideation</option>
+          <option value="validation">Validation</option>
+          <option value="building">Building</option>
+          <option value="launched">Launched</option>
+        </select>
+      </div>
+      <div class="filter-group">
+        <label class="filter-label">Sort by</label>
+        <select class="filter-select" id="filterSort">
+          <option value="trending">Trending</option>
+          <option value="newest">Newest first</option>
+          <option value="votes">Most votes</option>
+        </select>
+      </div>
+      <button class="btn btn-outline-iih reset-btn" id="resetFilters">
+        <i class="bi bi-arrow-counterclockwise"></i> Reset
+      </button>
+    </div>
+
+    <div class="results-count">
+      Showing <strong id="resultsCount">9</strong> ideas
+    </div>
+  </section>
+
+  <!-- ═══════════ IDEA GRID ═══════════ -->
+  <section class="container-iih mt-3 mb-5">
+    <div class="row g-4" id="ideaGrid">
+
+      <!-- Idea 1 -->
+      <div class="col-md-6 col-lg-4 idea-item" data-category="EdTech" data-stage="building" data-title="duolingo for musical instruments">
+        <a href="idea-detail.html" class="text-decoration-none">
+          <div class="idea-card card-iih h-100">
+            <div class="card-body-iih">
+              <div class="d-flex justify-content-between align-items-start mb-2">
+                <span class="tag tag-violet">EdTech</span>
+                <span class="stage-pill stage-building"><span class="stage-dot"></span>Building</span>
+              </div>
+              <h3 class="idea-card-title">Duolingo for musical instruments</h3>
+              <p class="idea-card-desc">Learn guitar, piano, or drums in 5-min daily lessons with streaks, leaderboards, and real song unlocks.</p>
+              <div class="idea-card-meta">
+                <div class="meta-item"><i class="bi bi-caret-up-fill text-brand"></i><strong>312</strong></div>
+                <div class="meta-item"><i class="bi bi-chat"></i>58</div>
+                <div class="meta-item"><i class="bi bi-people"></i>9</div>
+              </div>
+              <hr class="divider">
+              <div class="d-flex align-items-center gap-2">
+                <span class="avatar avatar-sm avatar-5">MK</span>
+                <div>
+                  <div class="small fw-semibold">Maya Kapoor</div>
+                  <div class="small text-muted-iih">5 days ago</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <!-- Idea 2 -->
+      <div class="col-md-6 col-lg-4 idea-item" data-category="FinTech" data-stage="validation" data-title="ai-powered budget coach for gen z">
+        <a href="idea-detail.html" class="text-decoration-none">
+          <div class="idea-card card-iih h-100">
+            <div class="card-body-iih">
+              <div class="d-flex justify-content-between align-items-start mb-2">
+                <span class="tag tag-brand">FinTech</span>
+                <span class="stage-pill stage-validation"><span class="stage-dot"></span>Validation</span>
+              </div>
+              <h3 class="idea-card-title">AI-powered budget coach for Gen Z</h3>
+              <p class="idea-card-desc">A no-judgment money buddy that roasts your spending in a fun way and helps you save without feeling restricted.</p>
+              <div class="idea-card-meta">
+                <div class="meta-item"><i class="bi bi-caret-up-fill text-brand"></i><strong>247</strong></div>
+                <div class="meta-item"><i class="bi bi-chat"></i>34</div>
+                <div class="meta-item"><i class="bi bi-people"></i>6</div>
+              </div>
+              <hr class="divider">
+              <div class="d-flex align-items-center gap-2">
+                <span class="avatar avatar-sm avatar-1">JL</span>
+                <div>
+                  <div class="small fw-semibold">Jamie Liu</div>
+                  <div class="small text-muted-iih">2 days ago</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <!-- Idea 3 -->
+      <div class="col-md-6 col-lg-4 idea-item" data-category="GreenTech" data-stage="ideation" data-title="carbon-negative coffee subscription">
+        <a href="idea-detail.html" class="text-decoration-none">
+          <div class="idea-card card-iih h-100">
+            <div class="card-body-iih">
+              <div class="d-flex justify-content-between align-items-start mb-2">
+                <span class="tag tag-mint">GreenTech</span>
+                <span class="stage-pill stage-ideation"><span class="stage-dot"></span>Ideation</span>
+              </div>
+              <h3 class="idea-card-title">Carbon-negative coffee subscription</h3>
+              <p class="idea-card-desc">Every bag offsets 2x its footprint via verified reforestation partners. Ethical bean sourcing baked in.</p>
+              <div class="idea-card-meta">
+                <div class="meta-item"><i class="bi bi-caret-up-fill text-brand"></i><strong>189</strong></div>
+                <div class="meta-item"><i class="bi bi-chat"></i>21</div>
+                <div class="meta-item"><i class="bi bi-people"></i>3</div>
+              </div>
+              <hr class="divider">
+              <div class="d-flex align-items-center gap-2">
+                <span class="avatar avatar-sm avatar-3">SR</span>
+                <div>
+                  <div class="small fw-semibold">Sam Reyes</div>
+                  <div class="small text-muted-iih">1 week ago</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <!-- Idea 4 -->
+      <div class="col-md-6 col-lg-4 idea-item" data-category="DevTools" data-stage="launched" data-title="codereview buddy pair with expert">
+        <a href="idea-detail.html" class="text-decoration-none">
+          <div class="idea-card card-iih h-100">
+            <div class="card-body-iih">
+              <div class="d-flex justify-content-between align-items-start mb-2">
+                <span class="tag tag-dark">DevTools</span>
+                <span class="stage-pill stage-launched"><span class="stage-dot"></span>Launched</span>
+              </div>
+              <h3 class="idea-card-title">CodeReview buddy — pair with an expert in 30 min</h3>
+              <p class="idea-card-desc">Get 30 minutes of structured code review from verified senior engineers. Pay per session, no retainer.</p>
+              <div class="idea-card-meta">
+                <div class="meta-item"><i class="bi bi-caret-up-fill text-brand"></i><strong>418</strong></div>
+                <div class="meta-item"><i class="bi bi-chat"></i>71</div>
+                <div class="meta-item"><i class="bi bi-people"></i>4</div>
+              </div>
+              <hr class="divider">
+              <div class="d-flex align-items-center gap-2">
+                <span class="avatar avatar-sm avatar-1">JL</span>
+                <div>
+                  <div class="small fw-semibold">Jamie Liu</div>
+                  <div class="small text-muted-iih">3 weeks ago</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <!-- Idea 5 -->
+      <div class="col-md-6 col-lg-4 idea-item" data-category="Health" data-stage="validation" data-title="mindfulness breaks during video calls">
+        <a href="idea-detail.html" class="text-decoration-none">
+          <div class="idea-card card-iih h-100">
+            <div class="card-body-iih">
+              <div class="d-flex justify-content-between align-items-start mb-2">
+                <span class="tag tag-pink">Health</span>
+                <span class="stage-pill stage-validation"><span class="stage-dot"></span>Validation</span>
+              </div>
+              <h3 class="idea-card-title">3-minute mindfulness breaks during video calls</h3>
+              <p class="idea-card-desc">A Chrome extension that suggests guided breathing between your back-to-back meetings. Stop burning out.</p>
+              <div class="idea-card-meta">
+                <div class="meta-item"><i class="bi bi-caret-up-fill text-brand"></i><strong>203</strong></div>
+                <div class="meta-item"><i class="bi bi-chat"></i>45</div>
+                <div class="meta-item"><i class="bi bi-people"></i>5</div>
+              </div>
+              <hr class="divider">
+              <div class="d-flex align-items-center gap-2">
+                <span class="avatar avatar-sm avatar-4">PA</span>
+                <div>
+                  <div class="small fw-semibold">Priya Ahmed</div>
+                  <div class="small text-muted-iih">3 days ago</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <!-- Idea 6 -->
+      <div class="col-md-6 col-lg-4 idea-item" data-category="Productivity" data-stage="building" data-title="studyrooms virtual library focus sessions">
+        <a href="idea-detail.html" class="text-decoration-none">
+          <div class="idea-card card-iih h-100">
+            <div class="card-body-iih">
+              <div class="d-flex justify-content-between align-items-start mb-2">
+                <span class="tag tag-blue">Productivity</span>
+                <span class="stage-pill stage-building"><span class="stage-dot"></span>Building</span>
+              </div>
+              <h3 class="idea-card-title">StudyRooms: virtual library for focus sessions</h3>
+              <p class="idea-card-desc">Body-doubling rooms where students join a silent video session to hold each other accountable. Pomodoro built-in.</p>
+              <div class="idea-card-meta">
+                <div class="meta-item"><i class="bi bi-caret-up-fill text-brand"></i><strong>198</strong></div>
+                <div class="meta-item"><i class="bi bi-chat"></i>42</div>
+                <div class="meta-item"><i class="bi bi-people"></i>3</div>
+              </div>
+              <hr class="divider">
+              <div class="d-flex align-items-center gap-2">
+                <span class="avatar avatar-sm avatar-6">TW</span>
+                <div>
+                  <div class="small fw-semibold">Taylor Wong</div>
+                  <div class="small text-muted-iih">3 days ago</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <!-- Idea 7 -->
+      <div class="col-md-6 col-lg-4 idea-item" data-category="Social" data-stage="ideation" data-title="plant swap marketplace apartment">
+        <a href="idea-detail.html" class="text-decoration-none">
+          <div class="idea-card card-iih h-100">
+            <div class="card-body-iih">
+              <div class="d-flex justify-content-between align-items-start mb-2">
+                <span class="tag tag-mint">Social</span>
+                <span class="stage-pill stage-ideation"><span class="stage-dot"></span>Ideation</span>
+              </div>
+              <h3 class="idea-card-title">Plant swap marketplace for apartment dwellers</h3>
+              <p class="idea-card-desc">Trade, rescue, or adopt houseplants with people in your building or suburb. Verified ID + community reviews.</p>
+              <div class="idea-card-meta">
+                <div class="meta-item"><i class="bi bi-caret-up-fill text-brand"></i><strong>89</strong></div>
+                <div class="meta-item"><i class="bi bi-chat"></i>12</div>
+                <div class="meta-item"><i class="bi bi-people"></i>1</div>
+              </div>
+              <hr class="divider">
+              <div class="d-flex align-items-center gap-2">
+                <span class="avatar avatar-sm avatar-1">JL</span>
+                <div>
+                  <div class="small fw-semibold">Jamie Liu</div>
+                  <div class="small text-muted-iih">1 week ago</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <!-- Idea 8 -->
+      <div class="col-md-6 col-lg-4 idea-item" data-category="FinTech" data-stage="ideation" data-title="splitwise recurring group bills subscriptions">
+        <a href="idea-detail.html" class="text-decoration-none">
+          <div class="idea-card card-iih h-100">
+            <div class="card-body-iih">
+              <div class="d-flex justify-content-between align-items-start mb-2">
+                <span class="tag tag-brand">FinTech</span>
+                <span class="stage-pill stage-ideation"><span class="stage-dot"></span>Ideation</span>
+              </div>
+              <h3 class="idea-card-title">Splitwise but for recurring group bills</h3>
+              <p class="idea-card-desc">Automate subscription splits (Netflix, Spotify, rent) with smart reminders and Venmo/PayID integration.</p>
+              <div class="idea-card-meta">
+                <div class="meta-item"><i class="bi bi-caret-up-fill text-brand"></i><strong>134</strong></div>
+                <div class="meta-item"><i class="bi bi-chat"></i>22</div>
+                <div class="meta-item"><i class="bi bi-people"></i>2</div>
+              </div>
+              <hr class="divider">
+              <div class="d-flex align-items-center gap-2">
+                <span class="avatar avatar-sm avatar-3">RC</span>
+                <div>
+                  <div class="small fw-semibold">Riley Chen</div>
+                  <div class="small text-muted-iih">6 days ago</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <!-- Idea 9 -->
+      <div class="col-md-6 col-lg-4 idea-item" data-category="EdTech" data-stage="validation" data-title="hyper-local art commissions marketplace">
+        <a href="idea-detail.html" class="text-decoration-none">
+          <div class="idea-card card-iih h-100">
+            <div class="card-body-iih">
+              <div class="d-flex justify-content-between align-items-start mb-2">
+                <span class="tag tag-yellow">Creator</span>
+                <span class="stage-pill stage-validation"><span class="stage-dot"></span>Validation</span>
+              </div>
+              <h3 class="idea-card-title">Hyper-local art commissions marketplace</h3>
+              <p class="idea-card-desc">Commission artists from your city. Support local, skip Etsy international shipping nightmares.</p>
+              <div class="idea-card-meta">
+                <div class="meta-item"><i class="bi bi-caret-up-fill text-brand"></i><strong>156</strong></div>
+                <div class="meta-item"><i class="bi bi-chat"></i>28</div>
+                <div class="meta-item"><i class="bi bi-people"></i>2</div>
+              </div>
+              <hr class="divider">
+              <div class="d-flex align-items-center gap-2">
+                <span class="avatar avatar-sm avatar-2">AG</span>
+                <div>
+                  <div class="small fw-semibold">Alex Garcia</div>
+                  <div class="small text-muted-iih">4 days ago</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+
+    </div>
+
+    <!-- Empty state -->
+    <div id="emptyState" class="empty-state" style="display:none;">
+      <div class="empty-icon"><i class="bi bi-search"></i></div>
+      <h3>No ideas match your filters</h3>
+      <p>Try different keywords or clear your filters.</p>
+      <button class="btn btn-brand" onclick="document.getElementById('resetFilters').click()">
+        <i class="bi bi-arrow-counterclockwise"></i> Reset filters
+      </button>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <footer class="footer-iih">
+    <div class="container-iih">
+      <div class="row g-4">
+        <div class="col-lg-4">
+          <a href="index.html" class="footer-brand">
+            <span class="brand-mark"><i class="bi bi-lightbulb-fill"></i></span>
+            Idea Incubator
+          </a>
+          <p style="color: var(--ink-400); max-width: 300px;">
+            The home for early-stage ideas, the builders behind them, and the community that helps ship them.
+          </p>
+          <div class="social-links mt-3">
+            <a href="#"><i class="bi bi-twitter-x"></i></a>
+            <a href="#"><i class="bi bi-github"></i></a>
+            <a href="#"><i class="bi bi-linkedin"></i></a>
+          </div>
+        </div>
+        <div class="col-6 col-md-3 col-lg-2"><h5>Product</h5><a href="explore.html">Explore</a><a href="dashboard.html">Dashboard</a><a href="submit-idea.html">Submit</a></div>
+        <div class="col-6 col-md-3 col-lg-2"><h5>Community</h5><a href="#">Guidelines</a><a href="#">Blog</a></div>
+        <div class="col-6 col-md-3 col-lg-2"><h5>Company</h5><a href="about.html">About</a><a href="#">Contact</a></div>
+        <div class="col-6 col-md-3 col-lg-2"><h5>Legal</h5><a href="#">Terms</a><a href="#">Privacy</a></div>
+      </div>
+      <div class="footer-bottom">
+        <div>© 2026 Idea Incubator Hub. Built for CITS3403/5505.</div>
+        <div>Made with <span style="color: var(--brand-primary);">♥</span> in Perth, WA.</div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="../assets/js/main.js"></script>
+  <script src="../assets/js/explore.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Adds an Explore page where users can browse community ideas in a card grid, search by keyword (title/category), filter by category and stage, sort (trending / newest / most votes), and reset filters. Includes styling and scripts for the page, plus links from the landing flow so search can open Explore with a ?q= query when relevant.