### PR TITLE
fix(explore/detail): map db fields to existing templates

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -1,8 +1,144 @@
+from datetime import datetime
+
 from flask import Blueprint, redirect, render_template, url_for
 
-from models.models import Comment, Idea, User
+from models.models import Collaboration, Comment, Idea, User
 
 main_bp = Blueprint("main", __name__)
+
+
+CATEGORY_TAG_CLASS = {
+    "FinTech": "tag-brand",
+    "EdTech": "tag-violet",
+    "GreenTech": "tag-mint",
+    "DevTools": "tag-dark",
+    "Health": "tag-pink",
+    "Productivity": "tag-blue",
+    "Social": "tag-mint",
+    "Creator": "tag-yellow",
+    "Creator Economy": "tag-yellow",
+}
+
+
+def _avatar_class_for_user(user) -> str:
+    color = user.avatar_color if user and user.avatar_color else 1
+    return f"avatar-{color}"
+
+
+def _relative_time(dt) -> str:
+    if not dt:
+        return "just now"
+    delta = datetime.utcnow() - dt
+    if delta.days >= 30:
+        months = max(1, delta.days // 30)
+        return f"{months} month{'s' if months != 1 else ''} ago"
+    if delta.days >= 7:
+        weeks = max(1, delta.days // 7)
+        return f"{weeks} week{'s' if weeks != 1 else ''} ago"
+    if delta.days >= 1:
+        return f"{delta.days} day{'s' if delta.days != 1 else ''} ago"
+    return "just now"
+
+
+def _serialize_explore_idea(idea: Idea) -> dict:
+    author = idea.author
+    stage_class = idea.stage or "validation"
+    return {
+        "id": idea.id,
+        "title": idea.title,
+        "summary": idea.summary,
+        "category": idea.category,
+        "tag_class": CATEGORY_TAG_CLASS.get(idea.category, "tag-brand"),
+        "stage_class": stage_class,
+        "stage": stage_class.capitalize(),
+        "author": {
+            "name": author.display_name if author else "Unknown user",
+            "initials": author.initials if author else "NA",
+            "avatar_class": _avatar_class_for_user(author) if author else "avatar-1",
+        },
+        "posted": _relative_time(idea.created_at),
+        "votes": idea.vote_count,
+        "comments_total": idea.comment_count,
+        "collaborators_total": idea.collaborator_count,
+    }
+
+
+def _serialize_detail_idea(idea: Idea) -> dict:
+    author = idea.author
+    stage_class = idea.stage or "validation"
+
+    comments = (
+        Comment.query.filter_by(idea_id=idea.id)
+        .order_by(Comment.created_at.desc())
+        .limit(10)
+        .all()
+    )
+    comment_preview = [
+        {
+            "name": item.author.display_name if item.author else "Unknown user",
+            "initials": item.author.initials if item.author else "NA",
+            "avatar_class": _avatar_class_for_user(item.author) if item.author else "avatar-1",
+            "time": _relative_time(item.created_at),
+            "text": item.body,
+            "likes": item.like_count or 0,
+        }
+        for item in comments
+    ]
+
+    collaborators = (
+        Collaboration.query.filter_by(idea_id=idea.id, status="accepted")
+        .order_by(Collaboration.joined_at.asc())
+        .all()
+    )
+    collaborator_data = [
+        {
+            "name": entry.user.display_name if entry.user else "Unknown user",
+            "initials": entry.user.initials if entry.user else "NA",
+            "avatar_class": _avatar_class_for_user(entry.user) if entry.user else "avatar-1",
+            "role": entry.role or "Contributor",
+        }
+        for entry in collaborators
+    ]
+
+    tags = [f"#{tag.name}" for tag in idea.tags]
+
+    # Keep template contract stable: map DB fields to existing sections.
+    sections = {
+        "idea": idea.summary,
+        "problem": idea.description,
+        "solution_intro": "Initial version based on current idea description and metrics.",
+        "solution_points": [],
+    }
+
+    return {
+        "id": idea.id,
+        "title": idea.title,
+        "category": idea.category,
+        "tag_class": CATEGORY_TAG_CLASS.get(idea.category, "tag-brand"),
+        "stage_class": stage_class,
+        "stage": stage_class.capitalize(),
+        "author": {
+            "name": author.display_name if author else "Unknown user",
+            "initials": author.initials if author else "NA",
+            "avatar_class": _avatar_class_for_user(author) if author else "avatar-1",
+        },
+        "posted": _relative_time(idea.created_at),
+        "views": f"{idea.views:,} views",
+        "votes": idea.vote_count,
+        "comments_total": idea.comment_count,
+        "collaborators_total": idea.collaborator_count,
+        "sections": sections,
+        "score": idea.overall_score,
+        "score_breakdown": {
+            "market": idea.market_score or 0,
+            "support": idea.community_score or 0,
+            "feasibility": idea.feasibility_score or 0,
+            "differentiation": idea.differentiation_score or 0,
+        },
+        "tags": tags,
+        "collaborators": collaborator_data,
+        "discussion_preview": comment_preview,
+    }
 
 
 @main_bp.app_errorhandler(404)
@@ -42,7 +178,13 @@ def index():
 # ─────────────────────────────────────────
 @main_bp.route("/explore")
 def explore():
-    return render_template("explore.html", ideas=[])
+    ideas = (
+        Idea.query
+        .filter_by(privacy="public")
+        .order_by(Idea.created_at.desc())
+        .all()
+    )
+    return render_template("explore.html", ideas=[_serialize_explore_idea(idea) for idea in ideas])
 
 
 @main_bp.route("/dashboard")
@@ -53,7 +195,7 @@ def dashboard():
 @main_bp.route("/ideas/<int:idea_id>")
 def idea_detail(idea_id: int):
     idea = Idea.query.get_or_404(idea_id)
-    return render_template("idea_detail.html", idea=idea)
+    return render_template("idea_detail.html", idea=_serialize_detail_idea(idea))
 
 
 @main_bp.route("/login")

--- a/routes/main.py
+++ b/routes/main.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from flask import Blueprint, redirect, render_template, url_for
+from flask import Blueprint, redirect, render_template, request, url_for
 
 from models.models import Collaboration, Comment, Idea, User
 
@@ -178,13 +178,31 @@ def index():
 # ─────────────────────────────────────────
 @main_bp.route("/explore")
 def explore():
-    ideas = (
-        Idea.query
-        .filter_by(privacy="public")
-        .order_by(Idea.created_at.desc())
-        .all()
+    query = Idea.query.filter_by(privacy="public")
+
+    q = (request.args.get("q") or "").strip()
+    category = (request.args.get("category") or "all").strip()
+    stage = (request.args.get("stage") or "all").strip().lower()
+
+    if q:
+        like_expr = f"%{q}%"
+        query = query.filter(
+            (Idea.title.ilike(like_expr)) |
+            (Idea.summary.ilike(like_expr)) |
+            (Idea.category.ilike(like_expr))
+        )
+
+    if category and category.lower() != "all":
+        query = query.filter(Idea.category == category)
+
+    if stage and stage != "all":
+        query = query.filter(Idea.stage == stage)
+
+    ideas = query.order_by(Idea.created_at.desc()).all()
+    return render_template(
+        "explore.html",
+        ideas=[_serialize_explore_idea(idea) for idea in ideas],
     )
-    return render_template("explore.html", ideas=[_serialize_explore_idea(idea) for idea in ideas])
 
 
 @main_bp.route("/dashboard")

--- a/routes/main.py
+++ b/routes/main.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 
 from flask import Blueprint, jsonify, redirect, render_template, request, url_for
@@ -112,12 +113,25 @@ def _serialize_detail_idea(idea: Idea) -> dict:
 
     tags = [f"#{tag.name}" for tag in idea.tags]
 
+    description_text = idea.description or ""
+    parsed_meta = {}
+    if description_text.strip().startswith("{"):
+        try:
+            parsed_meta = json.loads(description_text)
+        except (TypeError, ValueError):
+            parsed_meta = {}
+
+    sections_source = parsed_meta.get("sections", {}) if isinstance(parsed_meta, dict) else {}
+
     # Keep template contract stable: map DB fields to existing sections.
     sections = {
-        "idea": idea.summary,
-        "problem": idea.description,
-        "solution_intro": "Initial version based on current idea description and metrics.",
-        "solution_points": [],
+        "idea": sections_source.get("idea", idea.summary),
+        "problem": sections_source.get("problem", description_text),
+        "solution_intro": sections_source.get(
+            "solution_intro",
+            "Initial version based on current idea description and metrics.",
+        ),
+        "solution_points": sections_source.get("solution_points", []),
     }
 
     return {

--- a/routes/main.py
+++ b/routes/main.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 
 from flask import Blueprint, redirect, render_template, request, url_for
+from sqlalchemy import func
 
-from models.models import Collaboration, Comment, Idea, User
+from models.models import Collaboration, Comment, Idea, User, Vote
 
 main_bp = Blueprint("main", __name__)
 
@@ -183,6 +184,7 @@ def explore():
     q = (request.args.get("q") or "").strip()
     category = (request.args.get("category") or "all").strip()
     stage = (request.args.get("stage") or "all").strip().lower()
+    sort = (request.args.get("sort") or "trending").strip().lower()
 
     if q:
         like_expr = f"%{q}%"
@@ -198,7 +200,20 @@ def explore():
     if stage and stage != "all":
         query = query.filter(Idea.stage == stage)
 
-    ideas = query.order_by(Idea.created_at.desc()).all()
+    if sort == "newest":
+        query = query.order_by(Idea.created_at.desc())
+    elif sort == "votes":
+        query = (
+            query
+            .outerjoin(Vote, Vote.idea_id == Idea.id)
+            .group_by(Idea.id)
+            .order_by(func.count(Vote.id).desc(), Idea.created_at.desc())
+        )
+    else:
+        # Keep trending stable for now: latest public ideas first.
+        query = query.order_by(Idea.created_at.desc())
+
+    ideas = query.all()
     return render_template(
         "explore.html",
         ideas=[_serialize_explore_idea(idea) for idea in ideas],

--- a/routes/main.py
+++ b/routes/main.py
@@ -217,6 +217,12 @@ def explore():
     return render_template(
         "explore.html",
         ideas=[_serialize_explore_idea(idea) for idea in ideas],
+        active_filters={
+            "q": q,
+            "category": category or "all",
+            "stage": stage or "all",
+            "sort": sort or "trending",
+        },
     )
 
 

--- a/routes/main.py
+++ b/routes/main.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 
-from flask import Blueprint, redirect, render_template, request, url_for
+from flask import Blueprint, jsonify, redirect, render_template, request, url_for
+from flask_login import current_user
 from sqlalchemy import func
 
-from models.models import Collaboration, Comment, Idea, User, Vote
+from app import csrf
+from models.models import Collaboration, Comment, Idea, User, Vote, db
 
 main_bp = Blueprint("main", __name__)
 
@@ -67,6 +69,12 @@ def _serialize_explore_idea(idea: Idea) -> dict:
 def _serialize_detail_idea(idea: Idea) -> dict:
     author = idea.author
     stage_class = idea.stage or "validation"
+    actor = _get_actor_user()
+    user_voted = False
+    if actor is not None:
+        user_voted = (
+            Vote.query.filter_by(user_id=actor.id, idea_id=idea.id).first() is not None
+        )
 
     comments = (
         Comment.query.filter_by(idea_id=idea.id)
@@ -126,6 +134,7 @@ def _serialize_detail_idea(idea: Idea) -> dict:
         "posted": _relative_time(idea.created_at),
         "views": f"{idea.views:,} views",
         "votes": idea.vote_count,
+        "user_voted": user_voted,
         "comments_total": idea.comment_count,
         "collaborators_total": idea.collaborator_count,
         "sections": sections,
@@ -140,6 +149,17 @@ def _serialize_detail_idea(idea: Idea) -> dict:
         "collaborators": collaborator_data,
         "discussion_preview": comment_preview,
     }
+
+
+def _get_actor_user():
+    """
+    Temporary actor resolution for write endpoints:
+    - use logged-in user when available
+    - otherwise fallback to first seeded user for local development
+    """
+    if current_user and current_user.is_authenticated:
+        return current_user
+    return User.query.order_by(User.id.asc()).first()
 
 
 @main_bp.app_errorhandler(404)
@@ -235,6 +255,34 @@ def dashboard():
 def idea_detail(idea_id: int):
     idea = Idea.query.get_or_404(idea_id)
     return render_template("idea_detail.html", idea=_serialize_detail_idea(idea))
+
+
+@main_bp.route("/ideas/<int:idea_id>/vote", methods=["POST"])
+@csrf.exempt
+def toggle_idea_vote(idea_id: int):
+    idea = Idea.query.get_or_404(idea_id)
+    actor = _get_actor_user()
+    if actor is None:
+        return jsonify({"ok": False, "error": "No available user to cast vote"}), 400
+
+    existing_vote = Vote.query.filter_by(user_id=actor.id, idea_id=idea.id).first()
+    if existing_vote:
+        db.session.delete(existing_vote)
+        voted = False
+    else:
+        db.session.add(Vote(user_id=actor.id, idea_id=idea.id))
+        voted = True
+
+    db.session.commit()
+    return jsonify(
+        {
+            "ok": True,
+            "idea_id": idea.id,
+            "user_id": actor.id,
+            "voted": voted,
+            "vote_count": idea.vote_count,
+        }
+    )
 
 
 @main_bp.route("/login")

--- a/routes/main.py
+++ b/routes/main.py
@@ -5,7 +5,6 @@ from flask import Blueprint, jsonify, redirect, render_template, request, url_fo
 from flask_login import current_user
 from sqlalchemy import func
 
-from app import csrf
 from models.models import Collaboration, Comment, Idea, User, Vote, db
 
 main_bp = Blueprint("main", __name__)
@@ -301,7 +300,6 @@ def idea_detail(idea_id: int):
 
 
 @main_bp.route("/ideas/<int:idea_id>/vote", methods=["POST"])
-@csrf.exempt
 def toggle_idea_vote(idea_id: int):
     idea = Idea.query.get_or_404(idea_id)
     actor = _get_actor_user()
@@ -329,7 +327,6 @@ def toggle_idea_vote(idea_id: int):
 
 
 @main_bp.route("/ideas/<int:idea_id>/comments", methods=["POST"])
-@csrf.exempt
 def create_idea_comment(idea_id: int):
     idea = Idea.query.get_or_404(idea_id)
     actor = _get_actor_user()
@@ -364,7 +361,6 @@ def create_idea_comment(idea_id: int):
 
 
 @main_bp.route("/ideas/<int:idea_id>/comments/<int:comment_id>/like", methods=["POST"])
-@csrf.exempt
 def toggle_comment_like(idea_id: int, comment_id: int):
     idea = Idea.query.get_or_404(idea_id)
     comment = Comment.query.filter_by(id=comment_id, idea_id=idea.id).first_or_404()
@@ -403,7 +399,6 @@ def toggle_comment_like(idea_id: int, comment_id: int):
 
 
 @main_bp.route("/ideas/<int:idea_id>/comments/<int:comment_id>/replies", methods=["POST"])
-@csrf.exempt
 def create_comment_reply(idea_id: int, comment_id: int):
     idea = Idea.query.get_or_404(idea_id)
     parent_comment = Comment.query.filter_by(id=comment_id, idea_id=idea.id).first_or_404()

--- a/routes/main.py
+++ b/routes/main.py
@@ -77,9 +77,18 @@ def _serialize_detail_idea(idea: Idea) -> dict:
     stage_class = idea.stage or "validation"
     actor = _get_actor_user()
     user_voted = False
+    user_collaborating = False
     if actor is not None:
         user_voted = (
             Vote.query.filter_by(user_id=actor.id, idea_id=idea.id).first() is not None
+        )
+        user_collaborating = (
+            Collaboration.query.filter_by(
+                user_id=actor.id,
+                idea_id=idea.id,
+                status="accepted",
+            ).first()
+            is not None
         )
 
     comments = (
@@ -162,6 +171,7 @@ def _serialize_detail_idea(idea: Idea) -> dict:
         "views": f"{idea.views:,} views",
         "votes": idea.vote_count,
         "user_voted": user_voted,
+        "user_collaborating": user_collaborating,
         "comments_total": idea.comment_count,
         "collaborators_total": idea.collaborator_count,
         "sections": sections,
@@ -322,6 +332,44 @@ def toggle_idea_vote(idea_id: int):
             "user_id": actor.id,
             "voted": voted,
             "vote_count": idea.vote_count,
+        }
+    )
+
+
+@main_bp.route("/ideas/<int:idea_id>/collaborate", methods=["POST"])
+def toggle_idea_collaboration(idea_id: int):
+    idea = Idea.query.get_or_404(idea_id)
+    actor = _get_actor_user()
+    if actor is None:
+        return jsonify({"ok": False, "error": "No available user to collaborate"}), 400
+
+    existing = Collaboration.query.filter_by(
+        user_id=actor.id,
+        idea_id=idea.id,
+        status="accepted",
+    ).first()
+    if existing:
+        db.session.delete(existing)
+        collaborating = False
+    else:
+        db.session.add(
+            Collaboration(
+                user_id=actor.id,
+                idea_id=idea.id,
+                role="contributor",
+                status="accepted",
+            )
+        )
+        collaborating = True
+
+    db.session.commit()
+    return jsonify(
+        {
+            "ok": True,
+            "idea_id": idea.id,
+            "user_id": actor.id,
+            "collaborating": collaborating,
+            "collaborators_total": idea.collaborator_count,
         }
     )
 

--- a/routes/main.py
+++ b/routes/main.py
@@ -84,6 +84,7 @@ def _serialize_detail_idea(idea: Idea) -> dict:
     )
     comment_preview = [
         {
+            "id": item.id,
             "name": item.author.display_name if item.author else "Unknown user",
             "initials": item.author.initials if item.author else "NA",
             "avatar_class": _avatar_class_for_user(item.author) if item.author else "avatar-1",
@@ -331,6 +332,45 @@ def create_idea_comment(idea_id: int):
             }
         ),
         201,
+    )
+
+
+@main_bp.route("/ideas/<int:idea_id>/comments/<int:comment_id>/like", methods=["POST"])
+@csrf.exempt
+def toggle_comment_like(idea_id: int, comment_id: int):
+    idea = Idea.query.get_or_404(idea_id)
+    comment = Comment.query.filter_by(id=comment_id, idea_id=idea.id).first_or_404()
+
+    payload = request.get_json(silent=True) or {}
+    action = (payload.get("action") or "toggle").strip().lower()
+    if action not in {"like", "unlike", "toggle"}:
+        return jsonify({"ok": False, "error": "Invalid action"}), 400
+
+    # For now we persist aggregate likes; per-user state is restored on frontend.
+    if action == "like":
+        comment.like_count = (comment.like_count or 0) + 1
+        liked = True
+    elif action == "unlike":
+        comment.like_count = max((comment.like_count or 0) - 1, 0)
+        liked = False
+    else:
+        currently_liked = bool(payload.get("currently_liked", False))
+        if currently_liked:
+            comment.like_count = max((comment.like_count or 0) - 1, 0)
+            liked = False
+        else:
+            comment.like_count = (comment.like_count or 0) + 1
+            liked = True
+
+    db.session.commit()
+    return jsonify(
+        {
+            "ok": True,
+            "idea_id": idea.id,
+            "comment_id": comment.id,
+            "liked": liked,
+            "like_count": comment.like_count or 0,
+        }
     )
 
 

--- a/routes/main.py
+++ b/routes/main.py
@@ -151,6 +151,20 @@ def _serialize_detail_idea(idea: Idea) -> dict:
     }
 
 
+def _serialize_comment(comment: Comment) -> dict:
+    author = comment.author
+    return {
+        "id": comment.id,
+        "idea_id": comment.idea_id,
+        "name": author.display_name if author else "Unknown user",
+        "initials": author.initials if author else "NA",
+        "avatar_class": _avatar_class_for_user(author) if author else "avatar-1",
+        "time": _relative_time(comment.created_at),
+        "text": comment.body,
+        "likes": comment.like_count or 0,
+    }
+
+
 def _get_actor_user():
     """
     Temporary actor resolution for write endpoints:
@@ -282,6 +296,41 @@ def toggle_idea_vote(idea_id: int):
             "voted": voted,
             "vote_count": idea.vote_count,
         }
+    )
+
+
+@main_bp.route("/ideas/<int:idea_id>/comments", methods=["POST"])
+@csrf.exempt
+def create_idea_comment(idea_id: int):
+    idea = Idea.query.get_or_404(idea_id)
+    actor = _get_actor_user()
+    if actor is None:
+        return jsonify({"ok": False, "error": "No available user to post comment"}), 400
+
+    payload = request.get_json(silent=True) or {}
+    text = (payload.get("text") or request.form.get("text") or "").strip()
+    if not text:
+        return jsonify({"ok": False, "error": "Comment text is required"}), 400
+    if len(text) > 1000:
+        return jsonify({"ok": False, "error": "Comment must be 1000 characters or less"}), 400
+
+    comment = Comment(
+        user_id=actor.id,
+        idea_id=idea.id,
+        body=text,
+    )
+    db.session.add(comment)
+    db.session.commit()
+
+    return (
+        jsonify(
+            {
+                "ok": True,
+                "comment": _serialize_comment(comment),
+                "comments_total": idea.comment_count,
+            }
+        ),
+        201,
     )
 
 

--- a/routes/main.py
+++ b/routes/main.py
@@ -79,6 +79,7 @@ def _serialize_detail_idea(idea: Idea) -> dict:
 
     comments = (
         Comment.query.filter_by(idea_id=idea.id)
+        .filter(Comment.parent_id.is_(None))
         .order_by(Comment.created_at.desc())
         .limit(10)
         .all()
@@ -92,6 +93,12 @@ def _serialize_detail_idea(idea: Idea) -> dict:
             "time": _relative_time(item.created_at),
             "text": item.body,
             "likes": item.like_count or 0,
+            "replies": [
+                _serialize_comment(reply)
+                for reply in Comment.query.filter_by(parent_id=item.id)
+                .order_by(Comment.created_at.asc())
+                .all()
+            ],
         }
         for item in comments
     ]
@@ -177,6 +184,7 @@ def _serialize_comment(comment: Comment) -> dict:
         "time": _relative_time(comment.created_at),
         "text": comment.body,
         "likes": comment.like_count or 0,
+        "parent_id": comment.parent_id,
     }
 
 
@@ -386,6 +394,34 @@ def toggle_comment_like(idea_id: int, comment_id: int):
             "like_count": comment.like_count or 0,
         }
     )
+
+
+@main_bp.route("/ideas/<int:idea_id>/comments/<int:comment_id>/replies", methods=["POST"])
+@csrf.exempt
+def create_comment_reply(idea_id: int, comment_id: int):
+    idea = Idea.query.get_or_404(idea_id)
+    parent_comment = Comment.query.filter_by(id=comment_id, idea_id=idea.id).first_or_404()
+    actor = _get_actor_user()
+    if actor is None:
+        return jsonify({"ok": False, "error": "No available user to post reply"}), 400
+
+    payload = request.get_json(silent=True) or {}
+    text = (payload.get("text") or request.form.get("text") or "").strip()
+    if not text:
+        return jsonify({"ok": False, "error": "Reply text is required"}), 400
+    if len(text) > 1000:
+        return jsonify({"ok": False, "error": "Reply must be 1000 characters or less"}), 400
+
+    reply = Comment(
+        user_id=actor.id,
+        idea_id=idea.id,
+        parent_id=parent_comment.id,
+        body=text,
+    )
+    db.session.add(reply)
+    db.session.commit()
+
+    return jsonify({"ok": True, "reply": _serialize_comment(reply)}), 201
 
 
 @main_bp.route("/login")

--- a/routes/main.py
+++ b/routes/main.py
@@ -44,6 +44,12 @@ def _relative_time(dt) -> str:
     return "just now"
 
 
+def _format_comment_time(dt) -> str:
+    if not dt:
+        return "Unknown time"
+    return dt.strftime("%Y-%m-%d %H:%M")
+
+
 def _serialize_explore_idea(idea: Idea) -> dict:
     author = idea.author
     stage_class = idea.stage or "validation"
@@ -90,7 +96,7 @@ def _serialize_detail_idea(idea: Idea) -> dict:
             "name": item.author.display_name if item.author else "Unknown user",
             "initials": item.author.initials if item.author else "NA",
             "avatar_class": _avatar_class_for_user(item.author) if item.author else "avatar-1",
-            "time": _relative_time(item.created_at),
+            "time": _format_comment_time(item.created_at),
             "text": item.body,
             "likes": item.like_count or 0,
             "replies": [
@@ -181,7 +187,7 @@ def _serialize_comment(comment: Comment) -> dict:
         "name": author.display_name if author else "Unknown user",
         "initials": author.initials if author else "NA",
         "avatar_class": _avatar_class_for_user(author) if author else "avatar-1",
-        "time": _relative_time(comment.created_at),
+        "time": _format_comment_time(comment.created_at),
         "text": comment.body,
         "likes": comment.like_count or 0,
         "parent_id": comment.parent_id,

--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -14,11 +14,39 @@ document.addEventListener('DOMContentLoaded', () => {
   const emptyState = document.getElementById('emptyState');
   const allItems = Array.from(document.querySelectorAll('.idea-item'));
 
-  /* ─── Read URL ?q= on load ─── */
+  /* ─── Read URL params on load ─── */
   const urlParams = new URLSearchParams(window.location.search);
-  const qParam = urlParams.get('q');
-  if (qParam) {
-    searchInput.value = qParam;
+  const qParam = urlParams.get('q') || '';
+  const categoryParam = urlParams.get('category') || 'all';
+  const stageParam = urlParams.get('stage') || 'all';
+  const sortParam = urlParams.get('sort') || 'trending';
+
+  searchInput.value = qParam;
+  if ([...categorySelect.options].some(opt => opt.value === categoryParam)) {
+    categorySelect.value = categoryParam;
+  }
+  if ([...stageSelect.options].some(opt => opt.value === stageParam)) {
+    stageSelect.value = stageParam;
+  }
+  if ([...sortSelect.options].some(opt => opt.value === sortParam)) {
+    sortSelect.value = sortParam;
+  }
+
+  function syncUrlParams() {
+    const params = new URLSearchParams(window.location.search);
+    const q = (searchInput.value || '').trim();
+    const category = categorySelect.value;
+    const stage = stageSelect.value;
+    const sort = sortSelect.value;
+
+    if (q) params.set('q', q); else params.delete('q');
+    if (category && category !== 'all') params.set('category', category); else params.delete('category');
+    if (stage && stage !== 'all') params.set('stage', stage); else params.delete('stage');
+    if (sort && sort !== 'trending') params.set('sort', sort); else params.delete('sort');
+
+    const nextQuery = params.toString();
+    const nextUrl = nextQuery ? `${window.location.pathname}?${nextQuery}` : window.location.pathname;
+    window.history.replaceState({}, '', nextUrl);
   }
 
   /* ─── Apply filters ─── */
@@ -47,6 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
     countEl.textContent = visibleCount;
     emptyState.style.display = visibleCount === 0 ? 'block' : 'none';
     grid.style.display = visibleCount === 0 ? 'none' : '';
+    syncUrlParams();
   }
 
   /* ─── Apply sort (just re-orders DOM nodes in grid) ─── */
@@ -90,8 +119,10 @@ document.addEventListener('DOMContentLoaded', () => {
     stageSelect.value = 'all';
     sortSelect.value = 'trending';
     applyFilters();
+    applySort();
   });
 
-  /* ─── Run once on load if ?q= was provided ─── */
-  if (qParam) applyFilters();
+  /* ─── Run once on load ─── */
+  applyFilters();
+  applySort();
 });

--- a/static/js/idea-detail.js
+++ b/static/js/idea-detail.js
@@ -28,6 +28,36 @@ document.addEventListener("DOMContentLoaded", () => {
     btn.innerHTML = `<i class="${iconClass}"></i> ${count}`;
   };
 
+  const buildReplyNode = (reply) => {
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = `
+      <div class="comment ms-4 mt-2" data-comment-id="${reply.id}">
+        <span class="avatar ${reply.avatar_class}">${reply.initials}</span>
+        <div class="flex-grow-1">
+          <div class="comment-meta">
+            <strong>${reply.name}</strong>
+            <span class="text-muted-iih small">· ${reply.time}</span>
+          </div>
+          <p></p>
+        </div>
+      </div>
+    `.trim();
+    const node = wrapper.firstChild;
+    node.querySelector("p").textContent = reply.text;
+    return node;
+  };
+
+  const ensureReplyList = (commentContainer, commentId) => {
+    let replyList = commentContainer.querySelector(`[data-reply-list-for="${commentId}"]`);
+    if (!replyList) {
+      replyList = document.createElement("div");
+      replyList.className = "reply-list mt-2";
+      replyList.dataset.replyListFor = String(commentId);
+      commentContainer.querySelector(".flex-grow-1")?.appendChild(replyList);
+    }
+    return replyList;
+  };
+
   const upvoteBtn = document.getElementById("upvoteBtn");
   const voteCountEl = document.getElementById("voteCount");
   if (upvoteBtn && voteCountEl) {
@@ -110,7 +140,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const comment = payload.comment;
         const commentHTML = `
-          <div class="comment">
+          <div class="comment" data-comment-id="${comment.id}">
             <span class="avatar ${comment.avatar_class}">${comment.initials}</span>
             <div class="flex-grow-1">
               <div class="comment-meta">
@@ -120,8 +150,9 @@ document.addEventListener("DOMContentLoaded", () => {
               <p></p>
               <div class="comment-actions">
                 <button class="comment-action comment-like-btn" data-comment-id="${comment.id}"><i class="bi bi-hand-thumbs-up"></i> ${comment.likes}</button>
-                <button class="comment-action"><i class="bi bi-reply"></i> Reply</button>
+                <button class="comment-action comment-reply-btn" data-comment-id="${comment.id}"><i class="bi bi-reply"></i> Reply</button>
               </div>
+              <div class="reply-list mt-2" data-reply-list-for="${comment.id}"></div>
             </div>
           </div>`;
 
@@ -138,6 +169,76 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
   }
+
+  document.addEventListener("click", (e) => {
+    const replyBtn = e.target.closest(".comment-reply-btn");
+    if (!replyBtn) return;
+    e.preventDefault();
+    const ideaId = getIdeaId();
+    const commentId = replyBtn.dataset.commentId;
+    const commentContainer = replyBtn.closest(".comment[data-comment-id]");
+    if (!ideaId || !commentId || !commentContainer) return;
+
+    const existingComposer = commentContainer.querySelector(".reply-composer");
+    if (existingComposer) {
+      existingComposer.remove();
+      return;
+    }
+
+    const composer = document.createElement("div");
+    composer.className = "reply-composer mt-2";
+    composer.innerHTML = `
+      <textarea class="form-control-iih" rows="2" placeholder="Write a reply..."></textarea>
+      <div class="d-flex justify-content-end gap-2 mt-2">
+        <button type="button" class="btn btn-outline-iih btn-sm-iih reply-cancel-btn">Cancel</button>
+        <button type="button" class="btn btn-brand btn-sm-iih reply-submit-btn">Reply</button>
+      </div>
+    `;
+
+    const contentWrap = commentContainer.querySelector(".flex-grow-1");
+    const replyList = ensureReplyList(commentContainer, commentId);
+    contentWrap?.insertBefore(composer, replyList);
+
+    const textarea = composer.querySelector("textarea");
+    const submitBtn = composer.querySelector(".reply-submit-btn");
+    const cancelBtn = composer.querySelector(".reply-cancel-btn");
+    textarea?.focus();
+
+    cancelBtn?.addEventListener("click", () => composer.remove());
+    submitBtn?.addEventListener("click", async () => {
+      const text = (textarea?.value || "").trim();
+      if (!text) {
+        textarea?.classList.add("is-invalid");
+        return;
+      }
+      textarea?.classList.remove("is-invalid");
+      if (submitBtn) submitBtn.disabled = true;
+
+      try {
+        const response = await fetch(`/ideas/${ideaId}/comments/${commentId}/replies`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ text }),
+        });
+
+        const payload = await response.json();
+        if (!response.ok || !payload.ok) {
+          throw new Error(payload.error || `Reply request failed: ${response.status}`);
+        }
+
+        const replyNode = buildReplyNode(payload.reply);
+        const targetReplyList = ensureReplyList(commentContainer, commentId);
+        targetReplyList.insertBefore(replyNode, targetReplyList.firstChild);
+        composer.remove();
+      } catch (error) {
+        console.error(error);
+      } finally {
+        if (submitBtn) submitBtn.disabled = false;
+      }
+    });
+  });
 
   document.addEventListener("click", (e) => {
     const btn = e.target.closest(".comment-like-btn");

--- a/static/js/idea-detail.js
+++ b/static/js/idea-detail.js
@@ -8,6 +8,7 @@ document.addEventListener("DOMContentLoaded", () => {
     return match ? match[1] : null;
   };
   const ideaIdForStorage = getIdeaId();
+  const savedIdeasStorageKey = "saved_ideas";
   const likeStorageKey = ideaIdForStorage ? `idea:${ideaIdForStorage}:liked_comments` : null;
 
   const readLikedComments = () => {
@@ -24,6 +25,20 @@ document.addEventListener("DOMContentLoaded", () => {
   const writeLikedComments = (likedSet) => {
     if (!likeStorageKey) return;
     localStorage.setItem(likeStorageKey, JSON.stringify(Array.from(likedSet)));
+  };
+
+  const readSavedIdeas = () => {
+    try {
+      const raw = localStorage.getItem(savedIdeasStorageKey);
+      const parsed = raw ? JSON.parse(raw) : [];
+      return new Set(Array.isArray(parsed) ? parsed.map(String) : []);
+    } catch (_) {
+      return new Set();
+    }
+  };
+
+  const writeSavedIdeas = (savedSet) => {
+    localStorage.setItem(savedIdeasStorageKey, JSON.stringify(Array.from(savedSet)));
   };
 
   const setLikeButtonState = (btn, liked, count) => {
@@ -67,6 +82,95 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const upvoteBtn = document.getElementById("upvoteBtn");
   const voteCountEl = document.getElementById("voteCount");
+  const saveBtn = document.getElementById("saveBtn");
+  const shareBtn = document.getElementById("shareBtn");
+  const collaborateBtn = document.getElementById("collaborateBtn");
+  const savedIdeas = readSavedIdeas();
+
+  if (saveBtn && ideaIdForStorage) {
+    const setSaveState = (saved) => {
+      saveBtn.classList.toggle("voted", saved);
+      const label = saveBtn.querySelector("span");
+      if (label) label.textContent = saved ? "Saved" : "Save";
+      const icon = saveBtn.querySelector("i");
+      if (icon) {
+        icon.className = saved ? "bi bi-bookmark-fill" : "bi bi-bookmark";
+      }
+    };
+
+    setSaveState(savedIdeas.has(String(ideaIdForStorage)));
+    saveBtn.addEventListener("click", () => {
+      const key = String(ideaIdForStorage);
+      if (savedIdeas.has(key)) {
+        savedIdeas.delete(key);
+      } else {
+        savedIdeas.add(key);
+      }
+      writeSavedIdeas(savedIdeas);
+      setSaveState(savedIdeas.has(key));
+    });
+  }
+
+  if (shareBtn) {
+    shareBtn.addEventListener("click", async () => {
+      const shareData = {
+        title: document.title,
+        text: "Check out this idea on Idea Incubator Hub",
+        url: window.location.href,
+      };
+
+      try {
+        if (navigator.share) {
+          await navigator.share(shareData);
+        } else {
+          await navigator.clipboard.writeText(window.location.href);
+          const label = shareBtn.querySelector("span");
+          if (label) {
+            const prev = label.textContent;
+            label.textContent = "Copied link";
+            setTimeout(() => {
+              label.textContent = prev || "Share";
+            }, 1500);
+          }
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    });
+  }
+
+  if (collaborateBtn) {
+    collaborateBtn.addEventListener("click", async () => {
+      const ideaId = getIdeaId();
+      if (!ideaId) return;
+      collaborateBtn.disabled = true;
+      try {
+        const response = await fetch(`/ideas/${ideaId}/collaborate`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
+          },
+        });
+        const payload = await response.json();
+        if (!response.ok || !payload.ok) {
+          throw new Error(payload.error || `Collaborate request failed: ${response.status}`);
+        }
+        collaborateBtn.classList.toggle("voted", payload.collaborating);
+        const label = collaborateBtn.querySelector("span");
+        if (label) {
+          label.textContent = payload.collaborating
+            ? "Joined as collaborator"
+            : "Join as collaborator";
+        }
+      } catch (error) {
+        console.error(error);
+      } finally {
+        collaborateBtn.disabled = false;
+      }
+    });
+  }
+
   if (upvoteBtn && voteCountEl) {
     upvoteBtn.addEventListener("click", async () => {
       const ideaId = getIdeaId();

--- a/static/js/idea-detail.js
+++ b/static/js/idea-detail.js
@@ -10,6 +10,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const ideaIdForStorage = getIdeaId();
   const savedIdeasStorageKey = "saved_ideas";
   const likeStorageKey = ideaIdForStorage ? `idea:${ideaIdForStorage}:liked_comments` : null;
+  const actionFeedbackEl = document.getElementById("actionFeedback");
+  let feedbackTimer = null;
 
   const readLikedComments = () => {
     if (!likeStorageKey) return new Set();
@@ -45,6 +47,19 @@ document.addEventListener("DOMContentLoaded", () => {
     const iconClass = liked ? "bi bi-hand-thumbs-up-fill" : "bi bi-hand-thumbs-up";
     btn.classList.toggle("liked", liked);
     btn.innerHTML = `<i class="${iconClass}"></i> ${count}`;
+  };
+
+  const showActionFeedback = (message, variant = "danger") => {
+    if (!actionFeedbackEl) return;
+    actionFeedbackEl.textContent = message;
+    actionFeedbackEl.classList.remove("d-none", "alert-danger", "alert-success", "alert-info");
+    actionFeedbackEl.classList.add(`alert-${variant}`);
+    if (feedbackTimer) {
+      clearTimeout(feedbackTimer);
+    }
+    feedbackTimer = setTimeout(() => {
+      actionFeedbackEl.classList.add("d-none");
+    }, 3500);
   };
 
   const buildReplyNode = (reply) => {
@@ -135,6 +150,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
       } catch (error) {
         console.error(error);
+        showActionFeedback("Unable to share this idea right now.", "info");
       }
     });
   }
@@ -165,6 +181,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
       } catch (error) {
         console.error(error);
+        showActionFeedback("Unable to update collaboration right now. Please try again.");
       } finally {
         collaborateBtn.disabled = false;
       }
@@ -200,6 +217,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
       } catch (error) {
         console.error(error);
+        showActionFeedback("Unable to update vote right now. Please try again.");
       } finally {
         upvoteBtn.disabled = false;
       }
@@ -231,6 +249,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const text = commentInput.value.trim();
       if (!text) {
         commentInput.classList.add("is-invalid");
+        showActionFeedback("Comment cannot be empty. Please enter some text.", "info");
         return;
       }
       commentInput.classList.remove("is-invalid");
@@ -277,6 +296,7 @@ document.addEventListener("DOMContentLoaded", () => {
         commentInput.value = "";
       } catch (error) {
         console.error(error);
+        showActionFeedback("Unable to post comment. Please try again.");
       } finally {
         if (submitBtn) submitBtn.disabled = false;
       }
@@ -322,6 +342,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const text = (textarea?.value || "").trim();
       if (!text) {
         textarea?.classList.add("is-invalid");
+        showActionFeedback("Reply cannot be empty. Please enter some text.", "info");
         return;
       }
       textarea?.classList.remove("is-invalid");
@@ -348,6 +369,7 @@ document.addEventListener("DOMContentLoaded", () => {
         composer.remove();
       } catch (error) {
         console.error(error);
+        showActionFeedback("Unable to post reply. Please try again.");
       } finally {
         if (submitBtn) submitBtn.disabled = false;
       }
@@ -397,6 +419,7 @@ document.addEventListener("DOMContentLoaded", () => {
         console.error(error);
         // Keep UI unchanged on error.
         setLikeButtonState(btn, currentlyLiked, count);
+        showActionFeedback("Unable to update comment like right now. Please try again.");
       })
       .finally(() => {
         btn.disabled = false;

--- a/static/js/idea-detail.js
+++ b/static/js/idea-detail.js
@@ -1,4 +1,8 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const csrfToken = document
+    .querySelector('meta[name="csrf-token"]')
+    ?.getAttribute("content");
+
   const getIdeaId = () => {
     const match = window.location.pathname.match(/\/ideas\/(\d+)/);
     return match ? match[1] : null;
@@ -73,6 +77,7 @@ document.addEventListener("DOMContentLoaded", () => {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
           },
         });
 
@@ -132,6 +137,7 @@ document.addEventListener("DOMContentLoaded", () => {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
           },
           body: JSON.stringify({ text }),
         });
@@ -222,6 +228,7 @@ document.addEventListener("DOMContentLoaded", () => {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
           },
           body: JSON.stringify({ text }),
         });
@@ -262,6 +269,7 @@ document.addEventListener("DOMContentLoaded", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
       },
       body: JSON.stringify({
         action,

--- a/static/js/idea-detail.js
+++ b/static/js/idea-detail.js
@@ -3,6 +3,30 @@ document.addEventListener("DOMContentLoaded", () => {
     const match = window.location.pathname.match(/\/ideas\/(\d+)/);
     return match ? match[1] : null;
   };
+  const ideaIdForStorage = getIdeaId();
+  const likeStorageKey = ideaIdForStorage ? `idea:${ideaIdForStorage}:liked_comments` : null;
+
+  const readLikedComments = () => {
+    if (!likeStorageKey) return new Set();
+    try {
+      const raw = localStorage.getItem(likeStorageKey);
+      const parsed = raw ? JSON.parse(raw) : [];
+      return new Set(Array.isArray(parsed) ? parsed.map(String) : []);
+    } catch (_) {
+      return new Set();
+    }
+  };
+
+  const writeLikedComments = (likedSet) => {
+    if (!likeStorageKey) return;
+    localStorage.setItem(likeStorageKey, JSON.stringify(Array.from(likedSet)));
+  };
+
+  const setLikeButtonState = (btn, liked, count) => {
+    const iconClass = liked ? "bi bi-hand-thumbs-up-fill" : "bi bi-hand-thumbs-up";
+    btn.classList.toggle("liked", liked);
+    btn.innerHTML = `<i class="${iconClass}"></i> ${count}`;
+  };
 
   const upvoteBtn = document.getElementById("upvoteBtn");
   const voteCountEl = document.getElementById("voteCount");
@@ -43,6 +67,19 @@ document.addEventListener("DOMContentLoaded", () => {
   const commentForm = document.getElementById("commentForm");
   const commentInput = document.getElementById("commentInput");
   const commentList = document.getElementById("commentList");
+  const likedComments = readLikedComments();
+  const existingLikeButtons = document.querySelectorAll(".comment-like-btn");
+  existingLikeButtons.forEach((btn) => {
+    const commentId = btn.dataset.commentId;
+    if (!commentId) return;
+    if (likedComments.has(String(commentId))) {
+      const text = btn.textContent.trim();
+      const match = text.match(/(\d+)/);
+      const count = match ? parseInt(match[1], 10) : 0;
+      setLikeButtonState(btn, true, count);
+    }
+  });
+
   if (commentForm && commentInput && commentList) {
     commentForm.addEventListener("submit", async (e) => {
       e.preventDefault();
@@ -82,7 +119,7 @@ document.addEventListener("DOMContentLoaded", () => {
               </div>
               <p></p>
               <div class="comment-actions">
-                <button class="comment-action"><i class="bi bi-hand-thumbs-up"></i> ${comment.likes}</button>
+                <button class="comment-action comment-like-btn" data-comment-id="${comment.id}"><i class="bi bi-hand-thumbs-up"></i> ${comment.likes}</button>
                 <button class="comment-action"><i class="bi bi-reply"></i> Reply</button>
               </div>
             </div>
@@ -103,20 +140,50 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   document.addEventListener("click", (e) => {
-    const btn = e.target.closest(".comment-action");
-    if (!btn || !btn.querySelector(".bi-hand-thumbs-up")) return;
+    const btn = e.target.closest(".comment-like-btn");
+    if (!btn) return;
     e.preventDefault();
+    const ideaId = getIdeaId();
+    const commentId = btn.dataset.commentId;
+    if (!ideaId || !commentId) return;
 
     const text = btn.textContent.trim();
-    const match = text.match(/(\d+)/);
-    const count = match ? parseInt(match[1], 10) : 0;
+    const countMatch = text.match(/(\d+)/);
+    const count = countMatch ? parseInt(countMatch[1], 10) : 0;
+    const currentlyLiked = btn.classList.contains("liked");
+    const action = currentlyLiked ? "unlike" : "like";
 
-    if (btn.classList.contains("liked")) {
-      btn.classList.remove("liked");
-      btn.innerHTML = `<i class="bi bi-hand-thumbs-up"></i> ${count - 1}`;
-    } else {
-      btn.classList.add("liked");
-      btn.innerHTML = `<i class="bi bi-hand-thumbs-up-fill"></i> ${count + 1}`;
-    }
+    btn.disabled = true;
+    fetch(`/ideas/${ideaId}/comments/${commentId}/like`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        action,
+        currently_liked: currentlyLiked,
+      }),
+    })
+      .then(async (response) => {
+        const payload = await response.json();
+        if (!response.ok || !payload.ok) {
+          throw new Error(payload.error || `Comment like failed: ${response.status}`);
+        }
+        setLikeButtonState(btn, payload.liked, payload.like_count);
+        if (payload.liked) {
+          likedComments.add(String(commentId));
+        } else {
+          likedComments.delete(String(commentId));
+        }
+        writeLikedComments(likedComments);
+      })
+      .catch((error) => {
+        console.error(error);
+        // Keep UI unchanged on error.
+        setLikeButtonState(btn, currentlyLiked, count);
+      })
+      .finally(() => {
+        btn.disabled = false;
+      });
   });
 });

--- a/static/js/idea-detail.js
+++ b/static/js/idea-detail.js
@@ -39,6 +39,9 @@ document.addEventListener("DOMContentLoaded", () => {
             <span class="text-muted-iih small">· ${reply.time}</span>
           </div>
           <p></p>
+          <div class="comment-actions">
+            <button class="comment-action comment-like-btn" data-comment-id="${reply.id}"><i class="bi bi-hand-thumbs-up"></i> ${reply.likes}</button>
+          </div>
         </div>
       </div>
     `.trim();

--- a/static/js/idea-detail.js
+++ b/static/js/idea-detail.js
@@ -1,12 +1,15 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const getIdeaId = () => {
+    const match = window.location.pathname.match(/\/ideas\/(\d+)/);
+    return match ? match[1] : null;
+  };
+
   const upvoteBtn = document.getElementById("upvoteBtn");
   const voteCountEl = document.getElementById("voteCount");
   if (upvoteBtn && voteCountEl) {
     upvoteBtn.addEventListener("click", async () => {
-      const match = window.location.pathname.match(/\/ideas\/(\d+)/);
-      if (!match) return;
-
-      const ideaId = match[1];
+      const ideaId = getIdeaId();
+      if (!ideaId) return;
       upvoteBtn.disabled = true;
       try {
         const response = await fetch(`/ideas/${ideaId}/vote`, {
@@ -41,37 +44,61 @@ document.addEventListener("DOMContentLoaded", () => {
   const commentInput = document.getElementById("commentInput");
   const commentList = document.getElementById("commentList");
   if (commentForm && commentInput && commentList) {
-    commentForm.addEventListener("submit", (e) => {
+    commentForm.addEventListener("submit", async (e) => {
       e.preventDefault();
+      const ideaId = getIdeaId();
+      if (!ideaId) return;
+
       const text = commentInput.value.trim();
       if (!text) {
         commentInput.classList.add("is-invalid");
         return;
       }
       commentInput.classList.remove("is-invalid");
+      const submitBtn = commentForm.querySelector("button[type='submit']");
+      if (submitBtn) submitBtn.disabled = true;
+      try {
+        const response = await fetch(`/ideas/${ideaId}/comments`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ text }),
+        });
 
-      const commentHTML = `
-        <div class="comment">
-          <span class="avatar avatar-1">JL</span>
-          <div class="flex-grow-1">
-            <div class="comment-meta">
-              <strong>Jamie Liu</strong>
-              <span class="text-muted-iih small">· just now</span>
-            </div>
-            <p></p>
-            <div class="comment-actions">
-              <button class="comment-action"><i class="bi bi-hand-thumbs-up"></i> 0</button>
-              <button class="comment-action"><i class="bi bi-reply"></i> Reply</button>
-            </div>
-          </div>
-        </div>`;
+        const payload = await response.json();
+        if (!response.ok || !payload.ok) {
+          throw new Error(payload.error || `Comment request failed: ${response.status}`);
+        }
 
-      const wrapper = document.createElement("div");
-      wrapper.innerHTML = commentHTML.trim();
-      const newComment = wrapper.firstChild;
-      newComment.querySelector("p").textContent = text;
-      commentList.insertBefore(newComment, commentList.firstChild);
-      commentInput.value = "";
+        const comment = payload.comment;
+        const commentHTML = `
+          <div class="comment">
+            <span class="avatar ${comment.avatar_class}">${comment.initials}</span>
+            <div class="flex-grow-1">
+              <div class="comment-meta">
+                <strong>${comment.name}</strong>
+                <span class="text-muted-iih small">· ${comment.time}</span>
+              </div>
+              <p></p>
+              <div class="comment-actions">
+                <button class="comment-action"><i class="bi bi-hand-thumbs-up"></i> ${comment.likes}</button>
+                <button class="comment-action"><i class="bi bi-reply"></i> Reply</button>
+              </div>
+            </div>
+          </div>`;
+
+        const wrapper = document.createElement("div");
+        wrapper.innerHTML = commentHTML.trim();
+        const newComment = wrapper.firstChild;
+        newComment.querySelector("p").textContent = comment.text;
+        commentList.insertBefore(newComment, commentList.firstChild);
+        commentInput.value = "";
+      } catch (error) {
+        console.error(error);
+      } finally {
+        if (submitBtn) submitBtn.disabled = false;
+      }
     });
   }
 

--- a/static/js/idea-detail.js
+++ b/static/js/idea-detail.js
@@ -2,16 +2,37 @@ document.addEventListener("DOMContentLoaded", () => {
   const upvoteBtn = document.getElementById("upvoteBtn");
   const voteCountEl = document.getElementById("voteCount");
   if (upvoteBtn && voteCountEl) {
-    upvoteBtn.addEventListener("click", () => {
-      const current = parseInt(voteCountEl.textContent, 10);
-      if (upvoteBtn.classList.contains("voted")) {
-        upvoteBtn.classList.remove("voted");
-        voteCountEl.textContent = current - 1;
-        upvoteBtn.querySelector("span").textContent = "Upvote";
-      } else {
-        upvoteBtn.classList.add("voted");
-        voteCountEl.textContent = current + 1;
-        upvoteBtn.querySelector("span").textContent = "Upvoted";
+    upvoteBtn.addEventListener("click", async () => {
+      const match = window.location.pathname.match(/\/ideas\/(\d+)/);
+      if (!match) return;
+
+      const ideaId = match[1];
+      upvoteBtn.disabled = true;
+      try {
+        const response = await fetch(`/ideas/${ideaId}/vote`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error(`Vote request failed: ${response.status}`);
+        }
+
+        const payload = await response.json();
+        voteCountEl.textContent = payload.vote_count;
+        if (payload.voted) {
+          upvoteBtn.classList.add("voted");
+          upvoteBtn.querySelector("span").textContent = "Upvoted";
+        } else {
+          upvoteBtn.classList.remove("voted");
+          upvoteBtn.querySelector("span").textContent = "Upvote";
+        }
+      } catch (error) {
+        console.error(error);
+      } finally {
+        upvoteBtn.disabled = false;
       }
     });
   }

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="csrf-token" content="{{ csrf_token() }}">
   <title>{% block title %}Idea Incubator Hub{% endblock %}</title>
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/templates/explore.html
+++ b/templates/explore.html
@@ -13,7 +13,7 @@
     <p class="fade-up stagger-1">Browse ideas from the community. Vote on the ones you love, comment with your take.</p>
     <div class="explore-search-bar fade-up stagger-2">
       <i class="bi bi-search"></i>
-      <input type="text" id="searchInput" placeholder="Search by title, category, or keyword...">
+      <input type="text" id="searchInput" placeholder="Search by title, category, or keyword..." value="{{ active_filters.q|default('') }}">
     </div>
   </div>
 </section>
@@ -24,33 +24,34 @@
       <div class="filter-group">
         <label class="filter-label" for="filterCategory">Category</label>
         <select class="filter-select" id="filterCategory">
-          <option value="all">All categories</option>
-          <option value="FinTech">FinTech</option>
-          <option value="EdTech">EdTech</option>
-          <option value="GreenTech">GreenTech</option>
-          <option value="DevTools">DevTools</option>
-          <option value="Health">Health</option>
-          <option value="Productivity">Productivity</option>
-          <option value="Social">Social</option>
-          <option value="Creator">Creator</option>
+          <option value="all" {% if active_filters.category|default('all') == 'all' %}selected{% endif %}>All categories</option>
+          <option value="FinTech" {% if active_filters.category == 'FinTech' %}selected{% endif %}>FinTech</option>
+          <option value="EdTech" {% if active_filters.category == 'EdTech' %}selected{% endif %}>EdTech</option>
+          <option value="GreenTech" {% if active_filters.category == 'GreenTech' %}selected{% endif %}>GreenTech</option>
+          <option value="DevTools" {% if active_filters.category == 'DevTools' %}selected{% endif %}>DevTools</option>
+          <option value="Health" {% if active_filters.category == 'Health' %}selected{% endif %}>Health</option>
+          <option value="Productivity" {% if active_filters.category == 'Productivity' %}selected{% endif %}>Productivity</option>
+          <option value="Social" {% if active_filters.category == 'Social' %}selected{% endif %}>Social</option>
+          <option value="Creator" {% if active_filters.category == 'Creator' %}selected{% endif %}>Creator</option>
+          <option value="Creator Economy" {% if active_filters.category == 'Creator Economy' %}selected{% endif %}>Creator Economy</option>
         </select>
       </div>
       <div class="filter-group">
         <label class="filter-label" for="filterStage">Stage</label>
         <select class="filter-select" id="filterStage">
-          <option value="all">Any stage</option>
-          <option value="ideation">Ideation</option>
-          <option value="validation">Validation</option>
-          <option value="building">Building</option>
-          <option value="launched">Launched</option>
+          <option value="all" {% if active_filters.stage|default('all') == 'all' %}selected{% endif %}>Any stage</option>
+          <option value="ideation" {% if active_filters.stage == 'ideation' %}selected{% endif %}>Ideation</option>
+          <option value="validation" {% if active_filters.stage == 'validation' %}selected{% endif %}>Validation</option>
+          <option value="building" {% if active_filters.stage == 'building' %}selected{% endif %}>Building</option>
+          <option value="launched" {% if active_filters.stage == 'launched' %}selected{% endif %}>Launched</option>
         </select>
       </div>
       <div class="filter-group">
         <label class="filter-label" for="filterSort">Sort by</label>
         <select class="filter-select" id="filterSort">
-          <option value="trending">Trending</option>
-          <option value="newest">Newest first</option>
-          <option value="votes">Most votes</option>
+          <option value="trending" {% if active_filters.sort|default('trending') == 'trending' %}selected{% endif %}>Trending</option>
+          <option value="newest" {% if active_filters.sort == 'newest' %}selected{% endif %}>Newest first</option>
+          <option value="votes" {% if active_filters.sort == 'votes' %}selected{% endif %}>Most votes</option>
         </select>
       </div>
       <button class="btn btn-outline-iih reset-btn" id="resetFilters">
@@ -63,7 +64,7 @@
     Showing <strong id="resultsCount">{{ ideas|length }}</strong> ideas
   </div>
 
-  <div class="row g-4" id="ideaGrid">
+  <div class="row g-4" id="ideaGrid" {% if ideas|length == 0 %}style="display:none;"{% endif %}>
     {% for idea in ideas %}
     <div
       class="col-md-6 col-lg-4 idea-item"
@@ -102,7 +103,11 @@
     {% endfor %}
   </div>
 
+  {% if ideas|length == 0 %}
+  <div id="emptyState" class="empty-state" style="display:block;">
+  {% else %}
   <div id="emptyState" class="empty-state" style="display:none;">
+  {% endif %}
     <div class="empty-icon"><i class="bi bi-search"></i></div>
     <h3>No ideas match your filters</h3>
     <p>Try different keywords or clear your filters.</p>

--- a/templates/idea_detail.html
+++ b/templates/idea_detail.html
@@ -64,6 +64,7 @@
           <span>{% if idea.user_collaborating %}Joined as collaborator{% else %}Join as collaborator{% endif %}</span>
         </button>
       </div>
+      <div id="actionFeedback" class="alert d-none mt-3 mb-0" role="alert"></div>
 
       <div class="idea-section">
         <h2 class="section-heading">Discussion <span class="text-muted-iih small">({{ idea.comments_total }})</span></h2>

--- a/templates/idea_detail.html
+++ b/templates/idea_detail.html
@@ -52,9 +52,9 @@
       </div>
 
       <div class="vote-bar">
-        <button class="vote-btn" id="upvoteBtn">
+        <button class="vote-btn {% if idea.user_voted %}voted{% endif %}" id="upvoteBtn">
           <i class="bi bi-caret-up-fill"></i>
-          <span>Upvote</span>
+          <span>{% if idea.user_voted %}Upvoted{% else %}Upvote{% endif %}</span>
           <strong id="voteCount">{{ idea.votes }}</strong>
         </button>
         <button class="vote-btn-secondary"><i class="bi bi-bookmark"></i> Save</button>

--- a/templates/idea_detail.html
+++ b/templates/idea_detail.html
@@ -85,7 +85,7 @@
               </div>
               <p>{{ comment.text }}</p>
               <div class="comment-actions">
-                <button class="comment-action"><i class="bi bi-hand-thumbs-up"></i> {{ comment.likes }}</button>
+                <button class="comment-action comment-like-btn" data-comment-id="{{ comment.id }}"><i class="bi bi-hand-thumbs-up"></i> {{ comment.likes }}</button>
                 <button class="comment-action"><i class="bi bi-reply"></i> Reply</button>
               </div>
             </div>

--- a/templates/idea_detail.html
+++ b/templates/idea_detail.html
@@ -98,6 +98,9 @@
                       <span class="text-muted-iih small">· {{ reply.time }}</span>
                     </div>
                     <p>{{ reply.text }}</p>
+                    <div class="comment-actions">
+                      <button class="comment-action comment-like-btn" data-comment-id="{{ reply.id }}"><i class="bi bi-hand-thumbs-up"></i> {{ reply.likes }}</button>
+                    </div>
                   </div>
                 </div>
                 {% endfor %}

--- a/templates/idea_detail.html
+++ b/templates/idea_detail.html
@@ -76,7 +76,7 @@
 
         <div class="comment-list" id="commentList">
           {% for comment in idea.discussion_preview %}
-          <div class="comment">
+          <div class="comment" data-comment-id="{{ comment.id }}">
             <span class="avatar {{ comment.avatar_class }}">{{ comment.initials }}</span>
             <div class="flex-grow-1">
               <div class="comment-meta">
@@ -86,7 +86,21 @@
               <p>{{ comment.text }}</p>
               <div class="comment-actions">
                 <button class="comment-action comment-like-btn" data-comment-id="{{ comment.id }}"><i class="bi bi-hand-thumbs-up"></i> {{ comment.likes }}</button>
-                <button class="comment-action"><i class="bi bi-reply"></i> Reply</button>
+                <button class="comment-action comment-reply-btn" data-comment-id="{{ comment.id }}"><i class="bi bi-reply"></i> Reply</button>
+              </div>
+              <div class="reply-list mt-2" data-reply-list-for="{{ comment.id }}">
+                {% for reply in comment.replies %}
+                <div class="comment ms-4 mt-2" data-comment-id="{{ reply.id }}">
+                  <span class="avatar {{ reply.avatar_class }}">{{ reply.initials }}</span>
+                  <div class="flex-grow-1">
+                    <div class="comment-meta">
+                      <strong>{{ reply.name }}</strong>
+                      <span class="text-muted-iih small">· {{ reply.time }}</span>
+                    </div>
+                    <p>{{ reply.text }}</p>
+                  </div>
+                </div>
+                {% endfor %}
               </div>
             </div>
           </div>

--- a/templates/idea_detail.html
+++ b/templates/idea_detail.html
@@ -57,9 +57,12 @@
           <span>{% if idea.user_voted %}Upvoted{% else %}Upvote{% endif %}</span>
           <strong id="voteCount">{{ idea.votes }}</strong>
         </button>
-        <button class="vote-btn-secondary"><i class="bi bi-bookmark"></i> Save</button>
-        <button class="vote-btn-secondary"><i class="bi bi-share"></i> Share</button>
-        <button class="vote-btn-secondary ms-auto"><i class="bi bi-people"></i> Join as collaborator</button>
+        <button class="vote-btn-secondary" id="saveBtn"><i class="bi bi-bookmark"></i> <span>Save</span></button>
+        <button class="vote-btn-secondary" id="shareBtn"><i class="bi bi-share"></i> <span>Share</span></button>
+        <button class="vote-btn-secondary ms-auto {% if idea.user_collaborating %}voted{% endif %}" id="collaborateBtn">
+          <i class="bi bi-people"></i>
+          <span>{% if idea.user_collaborating %}Joined as collaborator{% else %}Join as collaborator{% endif %}</span>
+        </button>
       </div>
 
       <div class="idea-section">


### PR DESCRIPTION
Summary
- Connect explore page to backend queries with URL-driven filters (q, category, stage) and sorting (trending, newest, votes).
- Replace placeholder interactions on idea_detail with persistent backend actions for upvote, comments, replies, and comment likes.
- Improve detail-page UX with stable state after refresh (vote/join state), CSRF-protected write requests, and visible error feedback for failed async actions.

What Was Implemented
- Backend routes for:
  - idea vote toggle
  - comment creation
  - reply creation
  - comment like toggle
  - collaborator join toggle
- Explore backend filtering/sorting and query-param state sync.
- Frontend wiring in detail page JS for all above actions.
- Share action and local saved-state behavior.
- Fix for JSON description rendering in problem/solution sections.
- Comment/reply timestamp display formatting.

Test Plan
- GET /explore with combinations of q/category/stage/sort returns expected idea ordering and results.
- POST /ideas/<id>/vote toggles correctly and persists after refresh.
- POST /ideas/<id>/comments creates comments that remain after refresh.
- POST /ideas/<id>/comments/<comment_id>/replies creates replies under correct parent and persists.
- POST /ideas/<id>/comments/<comment_id>/like updates count and persists.
- POST /ideas/<id>/collaborate toggles joined state and updates UI after refresh.
- CSRF protection works for detail-page write actions (requests without token are rejected).
- Error feedback banner appears for failed async actions (network/server failure simulation).