### PR TITLE
Explore backend clean: gated explore UX, bookmark reliability, and idea detail enhancements

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,5 +1,6 @@
 # routes/auth.py
 import random
+from urllib.parse import urljoin, urlparse
 from flask_dance.contrib.google import google
 from flask import Blueprint, flash, redirect, render_template, request, url_for,current_app
 from flask_login import current_user, login_required, login_user, logout_user
@@ -10,6 +11,15 @@ from werkzeug.security import generate_password_hash
 from models.models import User, db
 
 auth_bp = Blueprint("auth", __name__)
+
+
+def _is_safe_redirect(target: str) -> bool:
+    if not target:
+        return False
+    host_url = request.host_url
+    test_url = urlparse(urljoin(host_url, target))
+    ref_url = urlparse(host_url)
+    return test_url.scheme in {"http", "https"} and ref_url.netloc == test_url.netloc
 
 
 # ─────────────────────────────────────────
@@ -75,6 +85,11 @@ def login():
     if current_user.is_authenticated:
         return redirect(url_for("main.index"))
 
+    next_page = request.args.get("next") or request.form.get("next") or ""
+    if not next_page:
+        referrer = request.referrer or ""
+        if _is_safe_redirect(referrer):
+            next_page = referrer
     if request.method == "POST":
         email    = request.form.get("email", "").strip().lower()
         password = request.form.get("password", "")
@@ -84,14 +99,15 @@ def login():
 
         if user is None or not user.check_password(password):
             flash("Incorrect email or password.")
-            return render_template("login.html")
+            return render_template("login.html", next_page=next_page)
 
         login_user(user, remember=remember)
 
-        next_page = request.args.get("next")
-        return redirect(next_page or url_for("main.dashboard"))
+        if next_page and _is_safe_redirect(next_page):
+            return redirect(next_page)
+        return redirect(url_for("main.dashboard"))
 
-    return render_template("login.html")
+    return render_template("login.html", next_page=next_page)
 
 
 # ─────────────────────────────────────────

--- a/routes/main.py
+++ b/routes/main.py
@@ -2,7 +2,7 @@ import json
 import os
 from urllib import error as urlerror
 from urllib import request as urlrequest
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from flask import Blueprint, jsonify, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
@@ -23,6 +23,19 @@ CATEGORY_TAG_CLASS = {
     "Social": "tag-mint",
     "Creator": "tag-yellow",
     "Creator Economy": "tag-yellow",
+}
+
+STAGE_FLOW = ["ideation", "validation", "building", "launched"]
+COLLABORATOR_ROLE_SUGGESTIONS = {
+    "FinTech": ["Backend developer", "Compliance advisor", "Product designer"],
+    "EdTech": ["Learning designer", "Frontend developer", "Growth marketer"],
+    "GreenTech": ["Operations specialist", "Data analyst", "Partnership lead"],
+    "DevTools": ["Developer advocate", "Backend developer", "Product manager"],
+    "Health": ["Domain expert", "Backend developer", "UX researcher"],
+    "Productivity": ["Frontend developer", "Product designer", "Growth marketer"],
+    "Social": ["Community manager", "Frontend developer", "Growth marketer"],
+    "Creator": ["Creator partnerships", "Product designer", "Growth marketer"],
+    "Creator Economy": ["Creator partnerships", "Product manager", "Growth marketer"],
 }
 
 
@@ -97,6 +110,59 @@ def _serialize_dashboard_idea(idea: Idea) -> dict:
         "collaborators": idea.collaborator_count,
         "views": f"{(idea.views or 0):,}",
         "updated": f"Updated {_relative_time(idea.updated_at or idea.created_at)}",
+    }
+
+
+def _serialize_public_snapshot_idea(idea: Idea) -> dict:
+    stage_class = idea.stage or "validation"
+    return {
+        "id": idea.id,
+        "title": idea.title,
+        "category": idea.category,
+        "tag_class": CATEGORY_TAG_CLASS.get(idea.category, "tag-brand"),
+        "summary": idea.summary,
+        "stage": stage_class.capitalize(),
+        "stage_class": stage_class,
+        "votes": idea.vote_count,
+        "comments": idea.comment_count,
+    }
+
+
+def _build_public_market_trends() -> list[dict]:
+    categories = (
+        db.session.query(Idea.category, func.count(Idea.id).label("idea_count"))
+        .filter_by(privacy="public")
+        .group_by(Idea.category)
+        .order_by(func.count(Idea.id).desc())
+        .limit(4)
+        .all()
+    )
+    total_public_ideas = Idea.query.filter_by(privacy="public").count() or 1
+    trend_items = []
+    for category, count in categories:
+        percentage = int((count / total_public_ideas) * 100)
+        trend_items.append(
+            {
+                "category": category,
+                "idea_count": count,
+                "share_percent": percentage,
+            }
+        )
+    return trend_items
+
+
+def _build_public_explore_context() -> dict:
+    snapshot_ideas = (
+        Idea.query.filter_by(privacy="public")
+        .order_by(Idea.created_at.desc())
+        .limit(8)
+        .all()
+    )
+    return {
+        "market_trends": _build_public_market_trends(),
+        "idea_snapshot": [_serialize_public_snapshot_idea(idea) for idea in snapshot_ideas],
+        "total_public_ideas": Idea.query.filter_by(privacy="public").count(),
+        "total_builders": User.query.count(),
     }
 
 
@@ -191,7 +257,7 @@ def _build_dashboard_activity(user_id: int, limit: int = 6) -> list[dict]:
 def _serialize_detail_idea(idea: Idea) -> dict:
     author = idea.author
     stage_class = idea.stage or "validation"
-    actor = _get_actor_user()
+    actor = current_user if current_user and current_user.is_authenticated else None
     user_voted = False
     user_collaborating = False
     if actor is not None:
@@ -247,6 +313,17 @@ def _serialize_detail_idea(idea: Idea) -> dict:
         }
         for entry in collaborators
     ]
+    collaborator_needs = _suggest_collaborator_needs(idea, collaborator_data)
+    related_ideas = (
+        Idea.query.filter(
+            Idea.privacy == "public",
+            Idea.id != idea.id,
+            Idea.category == idea.category,
+        )
+        .order_by(Idea.created_at.desc())
+        .limit(3)
+        .all()
+    )
 
     tags = [f"#{tag.name}" for tag in idea.tags]
 
@@ -290,6 +367,7 @@ def _serialize_detail_idea(idea: Idea) -> dict:
         "user_collaborating": user_collaborating,
         "comments_total": idea.comment_count,
         "collaborators_total": idea.collaborator_count,
+        "stage_timeline": _build_stage_timeline(stage_class),
         "sections": sections,
         "score": idea.overall_score,
         "score_breakdown": {
@@ -300,6 +378,9 @@ def _serialize_detail_idea(idea: Idea) -> dict:
         },
         "tags": tags,
         "collaborators": collaborator_data,
+        "collaborator_needs": collaborator_needs,
+        "related_ideas": [_serialize_related_idea(item) for item in related_ideas],
+        "weekly_momentum": _build_weekly_momentum(idea.id),
         "discussion_preview": comment_preview,
     }
 
@@ -317,6 +398,102 @@ def _serialize_comment(comment: Comment) -> dict:
         "likes": comment.like_count or 0,
         "parent_id": comment.parent_id,
     }
+
+
+def _build_stage_timeline(current_stage: str | None) -> list[dict]:
+    stage = (current_stage or "validation").lower()
+    current_idx = STAGE_FLOW.index(stage) if stage in STAGE_FLOW else 1
+    timeline = []
+    for idx, key in enumerate(STAGE_FLOW):
+        if idx < current_idx:
+            state = "completed"
+        elif idx == current_idx:
+            state = "active"
+        else:
+            state = "upcoming"
+        timeline.append(
+            {
+                "key": key,
+                "label": key.capitalize(),
+                "state": state,
+            }
+        )
+    return timeline
+
+
+def _suggest_collaborator_needs(idea: Idea, collaborators: list[dict]) -> list[str]:
+    suggestions = COLLABORATOR_ROLE_SUGGESTIONS.get(
+        idea.category,
+        ["Backend developer", "Product designer", "Growth marketer"],
+    )
+    existing_roles = {str(item.get("role", "")).strip().lower() for item in collaborators}
+    needed = []
+    for role in suggestions:
+        role_lower = role.lower()
+        if all(role_lower not in existing for existing in existing_roles):
+            needed.append(role)
+    return needed[:3]
+
+
+def _serialize_related_idea(idea: Idea) -> dict:
+    return {
+        "id": idea.id,
+        "title": idea.title,
+        "category": idea.category,
+        "tag_class": CATEGORY_TAG_CLASS.get(idea.category, "tag-brand"),
+        "summary": idea.summary,
+        "votes": idea.vote_count,
+    }
+
+
+def _build_weekly_momentum(idea_id: int) -> dict:
+    today = datetime.utcnow().date()
+    start_date = today - timedelta(days=6)
+
+    vote_rows = (
+        db.session.query(Vote.created_at)
+        .filter(
+            Vote.idea_id == idea_id,
+            Vote.created_at >= datetime.combine(start_date, datetime.min.time()),
+        )
+        .all()
+    )
+    comment_rows = (
+        db.session.query(Comment.created_at)
+        .filter(
+            Comment.idea_id == idea_id,
+            Comment.created_at >= datetime.combine(start_date, datetime.min.time()),
+        )
+        .all()
+    )
+
+    vote_by_day: dict[str, int] = {}
+    comment_by_day: dict[str, int] = {}
+    for (dt,) in vote_rows:
+        key = dt.date().isoformat()
+        vote_by_day[key] = vote_by_day.get(key, 0) + 1
+    for (dt,) in comment_rows:
+        key = dt.date().isoformat()
+        comment_by_day[key] = comment_by_day.get(key, 0) + 1
+
+    points = []
+    max_total = 1
+    for day_offset in range(7):
+        day = start_date + timedelta(days=day_offset)
+        key = day.isoformat()
+        votes = vote_by_day.get(key, 0)
+        comments = comment_by_day.get(key, 0)
+        total = votes + comments
+        max_total = max(max_total, total)
+        points.append(
+            {
+                "label": day.strftime("%a"),
+                "votes": votes,
+                "comments": comments,
+                "total": total,
+            }
+        )
+    return {"points": points, "max_total": max_total}
 
 
 def _build_ai_insights(idea: Idea) -> dict:
@@ -466,19 +643,6 @@ def _generate_ai_insights_with_openai(idea: Idea) -> dict:
         "provider": provider_name,
         "model": model,
     }
-
-
-def _get_actor_user():
-    """
-    Temporary actor resolution for write endpoints:
-    - use logged-in user when available
-    - otherwise fallback to first seeded user for local development
-    """
-    if current_user and current_user.is_authenticated:
-        return current_user
-    return User.query.order_by(User.id.asc()).first()
-
-
 @main_bp.app_errorhandler(404)
 def page_not_found(_error):
     return render_template("404.html"), 404
@@ -562,6 +726,12 @@ def explore():
         },
     )
 
+
+@main_bp.route("/explore/public")
+def explore_public():
+    return redirect(url_for("main.explore"))
+
+
 @main_bp.route("/dashboard")
 @login_required
 def dashboard():
@@ -632,17 +802,17 @@ def dashboard():
 
 
 @main_bp.route("/ideas/<int:idea_id>")
+@login_required
 def idea_detail(idea_id: int):
     idea = Idea.query.get_or_404(idea_id)
     return render_template("idea_detail.html", idea=_serialize_detail_idea(idea))
 
 
 @main_bp.route("/ideas/<int:idea_id>/vote", methods=["POST"])
+@login_required
 def toggle_idea_vote(idea_id: int):
     idea = Idea.query.get_or_404(idea_id)
-    actor = _get_actor_user()
-    if actor is None:
-        return jsonify({"ok": False, "error": "No available user to cast vote"}), 400
+    actor = current_user
 
     existing_vote = Vote.query.filter_by(user_id=actor.id, idea_id=idea.id).first()
     if existing_vote:
@@ -665,11 +835,10 @@ def toggle_idea_vote(idea_id: int):
 
 
 @main_bp.route("/ideas/<int:idea_id>/collaborate", methods=["POST"])
+@login_required
 def toggle_idea_collaboration(idea_id: int):
     idea = Idea.query.get_or_404(idea_id)
-    actor = _get_actor_user()
-    if actor is None:
-        return jsonify({"ok": False, "error": "No available user to collaborate"}), 400
+    actor = current_user
 
     existing = Collaboration.query.filter_by(
         user_id=actor.id,
@@ -703,11 +872,10 @@ def toggle_idea_collaboration(idea_id: int):
 
 
 @main_bp.route("/ideas/<int:idea_id>/comments", methods=["POST"])
+@login_required
 def create_idea_comment(idea_id: int):
     idea = Idea.query.get_or_404(idea_id)
-    actor = _get_actor_user()
-    if actor is None:
-        return jsonify({"ok": False, "error": "No available user to post comment"}), 400
+    actor = current_user
 
     payload = request.get_json(silent=True) or {}
     text = (payload.get("text") or request.form.get("text") or "").strip()
@@ -737,6 +905,7 @@ def create_idea_comment(idea_id: int):
 
 
 @main_bp.route("/ideas/<int:idea_id>/comments/<int:comment_id>/like", methods=["POST"])
+@login_required
 def toggle_comment_like(idea_id: int, comment_id: int):
     idea = Idea.query.get_or_404(idea_id)
     comment = Comment.query.filter_by(id=comment_id, idea_id=idea.id).first_or_404()
@@ -775,12 +944,11 @@ def toggle_comment_like(idea_id: int, comment_id: int):
 
 
 @main_bp.route("/ideas/<int:idea_id>/comments/<int:comment_id>/replies", methods=["POST"])
+@login_required
 def create_comment_reply(idea_id: int, comment_id: int):
     idea = Idea.query.get_or_404(idea_id)
     parent_comment = Comment.query.filter_by(id=comment_id, idea_id=idea.id).first_or_404()
-    actor = _get_actor_user()
-    if actor is None:
-        return jsonify({"ok": False, "error": "No available user to post reply"}), 400
+    actor = current_user
 
     payload = request.get_json(silent=True) or {}
     text = (payload.get("text") or request.form.get("text") or "").strip()
@@ -802,6 +970,7 @@ def create_comment_reply(idea_id: int, comment_id: int):
 
 
 @main_bp.route("/ideas/<int:idea_id>/ai-insights", methods=["POST"])
+@login_required
 def generate_idea_insights(idea_id: int):
     idea = Idea.query.get_or_404(idea_id)
     try:
@@ -1009,6 +1178,18 @@ def toggle_bookmark(idea_id: int):
 
     db.session.commit()
     return jsonify({"ok": True, "bookmarked": bookmarked})
+
+
+@main_bp.route("/api/ideas/<int:idea_id>/bookmark-status", methods=["GET"])
+@login_required
+def bookmark_status(idea_id: int):
+    """Return bookmark state on an idea for the current user."""
+    Idea.query.get_or_404(idea_id)
+    existing = Bookmark.query.filter_by(
+        user_id=current_user.id,
+        idea_id=idea_id,
+    ).first()
+    return jsonify({"ok": True, "bookmarked": existing is not None})
 
 @main_bp.route("/ideas/<int:idea_id>/board")
 @login_required

--- a/static/css/explore.css
+++ b/static/css/explore.css
@@ -133,8 +133,38 @@
 
 .idea-item.hide { display: none !important; }
 
+.explore-locked-shell {
+  position: relative;
+}
+
+.explore-header.is-locked,
+.filter-shell.is-locked {
+  filter: blur(5px);
+  user-select: none;
+  pointer-events: none;
+}
+
+.explore-locked-shell.is-locked #ideaGrid,
+.explore-locked-shell.is-locked #emptyState,
+.explore-locked-shell.is-locked .results-count {
+  filter: blur(5px);
+  user-select: none;
+  pointer-events: none;
+}
+
+.explore-lock-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
 @media (max-width: 767px) {
   .filter-bar { flex-direction: column; align-items: stretch; }
   .filter-group { min-width: 0; }
   .reset-btn { align-self: stretch; }
+  .explore-lock-overlay { flex-direction: column; }
 }

--- a/static/css/idea-detail.css
+++ b/static/css/idea-detail.css
@@ -27,6 +27,10 @@
   box-shadow: var(--shadow-card);
 }
 
+.sidebar-card {
+  padding: 1.25rem;
+}
+
 .idea-header-card {
   padding: 2rem;
   margin-bottom: 1.5rem;
@@ -54,6 +58,47 @@
 .idea-section li {
   color: var(--ink-700);
   line-height: 1.65;
+}
+
+.timeline-track {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.timeline-step {
+  border: 1px solid var(--ink-200);
+  border-radius: 12px;
+  padding: 0.6rem 0.7rem;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: var(--paper);
+}
+
+.timeline-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--ink-300);
+}
+
+.timeline-label {
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.timeline-step-completed .timeline-dot {
+  background: #10b981;
+}
+
+.timeline-step-active {
+  border-color: rgba(249, 115, 22, 0.45);
+  background: rgba(249, 115, 22, 0.08);
+}
+
+.timeline-step-active .timeline-dot {
+  background: var(--brand-primary);
 }
 
 .vote-bar {
@@ -162,6 +207,10 @@
   gap: 0.75rem;
   font-size: 0.85rem;
   color: var(--ink-700);
+  margin-bottom: 0.45rem;
+}
+.score-row:last-child {
+  margin-bottom: 0;
 }
 .score-bar {
   height: 6px;
@@ -174,6 +223,72 @@
   background: linear-gradient(90deg, var(--brand-primary) 0%, var(--brand-pink) 100%);
 }
 
+.momentum-chart {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.45rem;
+  align-items: end;
+  height: 110px;
+  padding: 0.4rem 0.2rem 0;
+}
+
+.momentum-day {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.momentum-bars {
+  display: flex;
+  align-items: end;
+  justify-content: center;
+  gap: 0.2rem;
+  width: 100%;
+  height: 80px;
+}
+
+.momentum-bar {
+  width: 9px;
+  min-height: 4px;
+  border-radius: 999px;
+}
+
+.momentum-bar-votes {
+  background: var(--brand-primary);
+}
+
+.momentum-bar-comments {
+  background: var(--brand-pink);
+}
+
+.momentum-day small {
+  font-size: 0.68rem;
+  color: var(--ink-500);
+  font-weight: 600;
+}
+
+.momentum-legend {
+  margin-top: 0.55rem;
+  display: flex;
+  gap: 0.85rem;
+  font-size: 0.78rem;
+  color: var(--ink-600);
+}
+
+.momentum-legend i {
+  font-size: 0.58rem;
+  margin-right: 0.25rem;
+}
+
+.momentum-legend i.votes {
+  color: var(--brand-primary);
+}
+
+.momentum-legend i.comments {
+  color: var(--brand-pink);
+}
+
 .collab-list {
   display: flex;
   flex-direction: column;
@@ -184,6 +299,15 @@
   align-items: center;
   gap: 0.7rem;
 }
+.collab-item > div {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+.collab-item span {
+  color: var(--ink-600);
+}
 .collab-item .avatar {
   display: inline-flex;
   align-items: center;
@@ -191,10 +315,47 @@
   text-align: center;
   line-height: 1;
 }
+.sidebar-card .btn {
+  margin-top: 0.9rem;
+}
+
+.related-idea-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.related-idea-item {
+  border: 1px solid var(--ink-200);
+  border-radius: 12px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: var(--ink-800);
+  background: var(--paper);
+}
+
+.related-idea-item:hover {
+  border-color: rgba(249, 115, 22, 0.4);
+  transform: translateY(-1px);
+}
+
+.related-idea-item strong {
+  line-height: 1.3;
+}
+
+.related-idea-item p {
+  font-size: 0.86rem;
+  color: var(--ink-600);
+  line-height: 1.5;
+}
 
 @media (max-width: 767px) {
   .idea-header-card,
   .idea-section { padding: 1.25rem; }
+  .sidebar-card { padding: 1rem; }
   .vote-bar { padding: 0.7rem; }
   .comment-composer { flex-direction: column; }
+  .timeline-track { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }

--- a/static/js/idea-detail.js
+++ b/static/js/idea-detail.js
@@ -8,7 +8,6 @@ document.addEventListener("DOMContentLoaded", () => {
     return match ? match[1] : null;
   };
   const ideaIdForStorage = getIdeaId();
-  const savedIdeasStorageKey = "saved_ideas";
   const likeStorageKey = ideaIdForStorage ? `idea:${ideaIdForStorage}:liked_comments` : null;
   const aiInsightsStorageKey = ideaIdForStorage ? `idea:${ideaIdForStorage}:ai_insights` : null;
   const actionFeedbackEl = document.getElementById("actionFeedback");
@@ -28,20 +27,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const writeLikedComments = (likedSet) => {
     if (!likeStorageKey) return;
     localStorage.setItem(likeStorageKey, JSON.stringify(Array.from(likedSet)));
-  };
-
-  const readSavedIdeas = () => {
-    try {
-      const raw = localStorage.getItem(savedIdeasStorageKey);
-      const parsed = raw ? JSON.parse(raw) : [];
-      return new Set(Array.isArray(parsed) ? parsed.map(String) : []);
-    } catch (_) {
-      return new Set();
-    }
-  };
-
-  const writeSavedIdeas = (savedSet) => {
-    localStorage.setItem(savedIdeasStorageKey, JSON.stringify(Array.from(savedSet)));
   };
 
   const readAiInsightsCache = () => {
@@ -113,7 +98,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const upvoteBtn = document.getElementById("upvoteBtn");
   const voteCountEl = document.getElementById("voteCount");
-  const saveBtn = document.getElementById("saveBtn");
+  const bookmarkBtn = document.getElementById("bookmarkBtn");
+  const bookmarkIcon = document.getElementById("bookmarkIcon");
+  const bookmarkLabel = document.getElementById("bookmarkLabel");
   const shareBtn = document.getElementById("shareBtn");
   const collaborateBtn = document.getElementById("collaborateBtn");
   const aiInsightsBtn = document.getElementById("aiInsightsBtn");
@@ -124,7 +111,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const aiStrengthsList = document.getElementById("aiStrengthsList");
   const aiSuggestionsList = document.getElementById("aiSuggestionsList");
   const aiDownloadBtn = document.getElementById("aiDownloadBtn");
-  const savedIdeas = readSavedIdeas();
   let currentAiInsights = readAiInsightsCache();
 
   const renderAiInsights = (insights) => {
@@ -243,27 +229,52 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  if (saveBtn && ideaIdForStorage) {
-    const setSaveState = (saved) => {
-      saveBtn.classList.toggle("voted", saved);
-      const label = saveBtn.querySelector("span");
-      if (label) label.textContent = saved ? "Saved" : "Save";
-      const icon = saveBtn.querySelector("i");
-      if (icon) {
-        icon.className = saved ? "bi bi-bookmark-fill" : "bi bi-bookmark";
+  if (bookmarkBtn && ideaIdForStorage) {
+    const setBookmarkState = (bookmarked) => {
+      bookmarkBtn.classList.toggle("voted", bookmarked);
+      if (bookmarkIcon) {
+        bookmarkIcon.className = bookmarked ? "bi bi-bookmark-fill" : "bi bi-bookmark";
+      }
+      if (bookmarkLabel) {
+        bookmarkLabel.textContent = bookmarked ? "Bookmarked" : "Bookmark";
       }
     };
 
-    setSaveState(savedIdeas.has(String(ideaIdForStorage)));
-    saveBtn.addEventListener("click", () => {
-      const key = String(ideaIdForStorage);
-      if (savedIdeas.has(key)) {
-        savedIdeas.delete(key);
-      } else {
-        savedIdeas.add(key);
+    const loadBookmarkState = async () => {
+      try {
+        const response = await fetch(`/api/ideas/${ideaIdForStorage}/bookmark-status`);
+        const payload = await response.json();
+        if (response.ok && payload.ok) {
+          setBookmarkState(Boolean(payload.bookmarked));
+        }
+      } catch (error) {
+        console.error(error);
       }
-      writeSavedIdeas(savedIdeas);
-      setSaveState(savedIdeas.has(key));
+    };
+
+    loadBookmarkState();
+    bookmarkBtn.addEventListener("click", async () => {
+      bookmarkBtn.disabled = true;
+      try {
+        const response = await fetch(`/api/ideas/${ideaIdForStorage}/bookmark`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
+          },
+        });
+        const payload = await response.json();
+        if (!response.ok || !payload.ok) {
+          throw new Error(payload.error || `Bookmark request failed: ${response.status}`);
+        }
+        const bookmarked = Boolean(payload.bookmarked);
+        setBookmarkState(bookmarked);
+      } catch (error) {
+        console.error(error);
+        showActionFeedback("Unable to update bookmark right now. Please try again.");
+      } finally {
+        bookmarkBtn.disabled = false;
+      }
     });
   }
 
@@ -567,31 +578,3 @@ document.addEventListener("DOMContentLoaded", () => {
       });
   });
 });
-
-// ── Bookmark toggle ────────────────────────────────────────────
-const bookmarkBtn = document.getElementById('bookmarkBtn');
-if (bookmarkBtn) {
-  bookmarkBtn.addEventListener('click', () => {
-    const ideaId = bookmarkBtn.dataset.ideaId;
-    fetch(`/api/ideas/${ideaId}/bookmark`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').content,
-      }
-    })
-    .then(r => r.json())
-    .then(data => {
-      if (!data.ok) return;
-      const icon  = document.getElementById('bookmarkIcon');
-      const label = document.getElementById('bookmarkLabel');
-      if (data.bookmarked) {
-        icon.className  = 'bi bi-bookmark-fill';
-        label.textContent = 'Bookmarked';
-      } else {
-        icon.className  = 'bi bi-bookmark';
-        label.textContent = 'Bookmark';
-      }
-    });
-  });
-}

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,10 @@
     <body data-page="{% block page_name %}{% endblock %}" {% block body_attrs %}{% endblock %}>
 
         {% set page = self.page_name() %}
+        {% set current_next = request.full_path %}
+        {% if current_next.endswith('?') %}
+            {% set current_next = request.path %}
+        {% endif %}
 
         {% if page == 'landing' and not current_user.is_authenticated %}
         <!-- Minimal navbar for landing page guests -->
@@ -26,7 +30,7 @@
                 <span>Idea Incubator</span>
             </a>
             <div class="d-flex align-items-center gap-3">
-                <a href="{{ url_for('auth.login') }}" class="btn btn-ghost">Log in</a>
+                <a href="{{ url_for('auth.login', next=current_next) }}" class="btn btn-ghost">Log in</a>
                 <a href="{{ url_for('auth.register') }}" class="btn btn-brand">Get started</a>
             </div>
             </div>
@@ -40,14 +44,19 @@
                 <span class="brand-mark"><i class="bi bi-lightbulb-fill"></i></span>
                 <span>Idea Incubator</span>
             </a>
+            {% if current_user.is_authenticated %}
             <button class="navbar-toggler border-0" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav">
                 <i class="bi bi-list fs-3"></i>
             </button>
             <div class="collapse navbar-collapse" id="mainNav">
                 <ul class="navbar-nav mx-auto mb-2 mb-lg-0">
-                <li class="nav-item"><a class="nav-link" href="/explore" data-page="explore">Explore</a></li>
-                <li class="nav-item"><a class="nav-link" href="/dashboard" data-page="dashboard">Dashboard</a></li>
+                <li class="nav-item">
+                  <a class="nav-link" href="{{ url_for('main.explore') }}" data-page="explore">Explore</a>
+                </li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('main.about') }}" data-page="about">About</a></li>
+                {% if current_user.is_authenticated %}
+                <li class="nav-item"><a class="nav-link" href="/dashboard" data-page="dashboard">Dashboard</a></li>
+                {% endif %}
                 </ul>
                 <div class="d-flex align-items-center gap-3">
                 {% if current_user.is_authenticated %}
@@ -97,11 +106,20 @@
                     </div>
                     </div>
                 {% else %}
-                    <a href="{{ url_for('auth.login') }}" class="btn btn-ghost">Log in</a>
+                    <a href="{{ url_for('auth.login', next=current_next) }}" class="btn btn-ghost">Log in</a>
                     <a href="{{ url_for('auth.register') }}" class="btn btn-brand">Get started</a>
                 {% endif %}
                 </div>
             </div>
+            {% else %}
+            <div class="d-flex align-items-center gap-3 mx-auto">
+                <a class="nav-link mb-0" href="{{ url_for('main.explore') }}" data-page="explore">Explore</a>
+            </div>
+            <div class="d-flex align-items-center gap-3">
+                <a href="{{ url_for('auth.login', next=current_next) }}" class="btn btn-ghost">Log in</a>
+                <a href="{{ url_for('auth.register') }}" class="btn btn-brand">Get started</a>
+            </div>
+            {% endif %}
             </div>
         </nav>
 

--- a/templates/explore.html
+++ b/templates/explore.html
@@ -7,7 +7,11 @@
 {% endblock %}
 
 {% block content %}
-<section class="explore-header">
+{% set current_next = request.full_path %}
+{% if current_next.endswith('?') %}
+  {% set current_next = request.path %}
+{% endif %}
+<section class="explore-header {% if not current_user.is_authenticated %}is-locked{% endif %}">
   <div class="container-iih">
     <h1 class="fade-up">Explore ideas</h1>
     <p class="fade-up stagger-1">Browse ideas from the community. Vote on the ones you love, comment with your take.</p>
@@ -19,7 +23,7 @@
 </section>
 
 <section class="container-iih mt-4 mb-5">
-  <div class="filter-shell">
+  <div class="filter-shell {% if not current_user.is_authenticated %}is-locked{% endif %}">
     <div class="filter-bar">
       <div class="filter-group">
         <label class="filter-label" for="filterCategory">Category</label>
@@ -60,60 +64,69 @@
     </div>
   </div>
 
-  <div class="results-count mb-3">
-    Showing <strong id="resultsCount">{{ ideas|length }}</strong> ideas
-  </div>
+  <div class="explore-locked-shell {% if not current_user.is_authenticated %}is-locked{% endif %}">
+    <div class="results-count mb-3">
+      Showing <strong id="resultsCount">{{ ideas|length }}</strong> ideas
+    </div>
 
-  <div class="row g-4" id="ideaGrid" {% if ideas|length == 0 %}style="display:none;"{% endif %}>
-    {% for idea in ideas %}
-    <div
-      class="col-md-6 col-lg-4 idea-item"
-      data-category="{{ idea.category }}"
-      data-stage="{{ idea.stage_class|default('validation') }}"
-      data-title="{{ idea.title|lower }}"
-    >
-      <a href="/ideas/{{ idea.id }}" class="text-decoration-none">
-        <div class="idea-card card-iih h-100">
-          <div class="card-body-iih">
-            <div class="d-flex justify-content-between align-items-start mb-2">
-              <span class="tag {{ idea.tag_class }}">{{ idea.category }}</span>
-              <span class="stage-pill stage-{{ idea.stage_class|default('validation') }}">
-                <span class="stage-dot"></span>{{ idea.stage|default("Validation") }}
-              </span>
-            </div>
-            <h3 class="idea-card-title">{{ idea.title }}</h3>
-            <p class="idea-card-desc">{{ idea.summary }}</p>
-            <div class="idea-card-meta">
-              <div class="meta-item"><i class="bi bi-caret-up-fill text-brand"></i><strong>{{ idea.votes }}</strong></div>
-              <div class="meta-item"><i class="bi bi-chat"></i>{{ idea.comments_total }}</div>
-              <div class="meta-item"><i class="bi bi-people"></i>{{ idea.collaborators_total }}</div>
-            </div>
-            <hr class="divider">
-            <div class="d-flex align-items-center gap-2">
-              <span class="avatar avatar-sm {{ idea.author.avatar_class }}">{{ idea.author.initials }}</span>
-              <div>
-                <div class="small fw-semibold">{{ idea.author.name }}</div>
-                <div class="small text-muted-iih">{{ idea.posted }}</div>
+    <div class="row g-4" id="ideaGrid" {% if ideas|length == 0 %}style="display:none;"{% endif %}>
+      {% for idea in ideas %}
+      <div
+        class="col-md-6 col-lg-4 idea-item"
+        data-category="{{ idea.category }}"
+        data-stage="{{ idea.stage_class|default('validation') }}"
+        data-title="{{ idea.title|lower }}"
+      >
+        <a href="/ideas/{{ idea.id }}" class="text-decoration-none">
+          <div class="idea-card card-iih h-100">
+            <div class="card-body-iih">
+              <div class="d-flex justify-content-between align-items-start mb-2">
+                <span class="tag {{ idea.tag_class }}">{{ idea.category }}</span>
+                <span class="stage-pill stage-{{ idea.stage_class|default('validation') }}">
+                  <span class="stage-dot"></span>{{ idea.stage|default("Validation") }}
+                </span>
+              </div>
+              <h3 class="idea-card-title">{{ idea.title }}</h3>
+              <p class="idea-card-desc">{{ idea.summary }}</p>
+              <div class="idea-card-meta">
+                <div class="meta-item"><i class="bi bi-caret-up-fill text-brand"></i><strong>{{ idea.votes }}</strong></div>
+                <div class="meta-item"><i class="bi bi-chat"></i>{{ idea.comments_total }}</div>
+                <div class="meta-item"><i class="bi bi-people"></i>{{ idea.collaborators_total }}</div>
+              </div>
+              <hr class="divider">
+              <div class="d-flex align-items-center gap-2">
+                <span class="avatar avatar-sm {{ idea.author.avatar_class }}">{{ idea.author.initials }}</span>
+                <div>
+                  <div class="small fw-semibold">{{ idea.author.name }}</div>
+                  <div class="small text-muted-iih">{{ idea.posted }}</div>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </a>
+        </a>
+      </div>
+      {% endfor %}
     </div>
-    {% endfor %}
-  </div>
 
-  {% if ideas|length == 0 %}
-  <div id="emptyState" class="empty-state" style="display:block;">
-  {% else %}
-  <div id="emptyState" class="empty-state" style="display:none;">
-  {% endif %}
-    <div class="empty-icon"><i class="bi bi-search"></i></div>
-    <h3>No ideas match your filters</h3>
-    <p>Try different keywords or clear your filters.</p>
-    <button class="btn btn-brand" onclick="document.getElementById('resetFilters').click()">
-      <i class="bi bi-arrow-counterclockwise"></i> Reset filters
-    </button>
+    {% if ideas|length == 0 %}
+    <div id="emptyState" class="empty-state" style="display:block;">
+    {% else %}
+    <div id="emptyState" class="empty-state" style="display:none;">
+    {% endif %}
+      <div class="empty-icon"><i class="bi bi-search"></i></div>
+      <h3>No ideas match your filters</h3>
+      <p>Try different keywords or clear your filters.</p>
+      <button class="btn btn-brand" onclick="document.getElementById('resetFilters').click()">
+        <i class="bi bi-arrow-counterclockwise"></i> Reset filters
+      </button>
+    </div>
+
+    {% if not current_user.is_authenticated %}
+    <div class="explore-lock-overlay">
+      <a class="btn btn-brand" href="{{ url_for('auth.login', next=current_next) }}">Log in</a>
+      <a class="btn btn-outline-iih" href="{{ url_for('auth.register') }}">Create account</a>
+    </div>
+    {% endif %}
   </div>
 </section>
 {% endblock %}

--- a/templates/idea_detail.html
+++ b/templates/idea_detail.html
@@ -32,6 +32,18 @@
       </div>
 
       <div class="idea-section">
+        <h2 class="section-heading">Progress timeline</h2>
+        <div class="timeline-track">
+          {% for item in idea.stage_timeline %}
+          <div class="timeline-step timeline-step-{{ item.state }}">
+            <span class="timeline-dot"></span>
+            <span class="timeline-label">{{ item.label }}</span>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+
+      <div class="idea-section">
         <h2 class="section-heading">The idea</h2>
         <p>{{ idea.sections.idea }}</p>
       </div>
@@ -182,6 +194,33 @@
       </div>
 
       <div class="sidebar-card mt-3">
+        <h4 class="sidebar-title">Weekly momentum</h4>
+        <div class="momentum-chart">
+          {% for point in idea.weekly_momentum.points %}
+          <div class="momentum-day">
+            <div class="momentum-bars">
+              <span
+                class="momentum-bar momentum-bar-votes"
+                style="height: {{ ((point.votes / idea.weekly_momentum.max_total) * 100)|round(0, 'ceil') if idea.weekly_momentum.max_total else 0 }}%;"
+                title="Votes: {{ point.votes }}"
+              ></span>
+              <span
+                class="momentum-bar momentum-bar-comments"
+                style="height: {{ ((point.comments / idea.weekly_momentum.max_total) * 100)|round(0, 'ceil') if idea.weekly_momentum.max_total else 0 }}%;"
+                title="Comments: {{ point.comments }}"
+              ></span>
+            </div>
+            <small>{{ point.label }}</small>
+          </div>
+          {% endfor %}
+        </div>
+        <div class="momentum-legend">
+          <span><i class="bi bi-square-fill votes"></i> Votes</span>
+          <span><i class="bi bi-square-fill comments"></i> Comments</span>
+        </div>
+      </div>
+
+      <div class="sidebar-card mt-3">
         <h4 class="sidebar-title">Collaborators <span class="text-muted-iih small fw-normal">({{ idea.collaborators_total }})</span></h4>
         <div class="collab-list">
           {% for member in idea.collaborators %}
@@ -197,12 +236,43 @@
       </div>
 
       <div class="sidebar-card mt-3">
+        <h4 class="sidebar-title">Looking for collaborators</h4>
+        {% if idea.collaborator_needs %}
+        <div class="d-flex gap-2 flex-wrap">
+          {% for role in idea.collaborator_needs %}
+          <span class="tag tag-blue">{{ role }}</span>
+          {% endfor %}
+        </div>
+        {% else %}
+        <p class="text-muted-iih mb-0">This team currently covers key roles.</p>
+        {% endif %}
+      </div>
+
+      <div class="sidebar-card mt-3">
         <h4 class="sidebar-title">Tags</h4>
         <div class="d-flex gap-2 flex-wrap">
           {% for tag in idea.tags %}
           <span class="tag">{{ tag }}</span>
           {% endfor %}
         </div>
+      </div>
+
+      <div class="sidebar-card mt-3">
+        <h4 class="sidebar-title">Related ideas</h4>
+        {% if idea.related_ideas %}
+        <div class="related-idea-list">
+          {% for related in idea.related_ideas %}
+          <a href="{{ url_for('main.idea_detail', idea_id=related.id) }}" class="related-idea-item text-decoration-none">
+            <span class="tag {{ related.tag_class }}">{{ related.category }}</span>
+            <strong>{{ related.title }}</strong>
+            <p class="mb-0">{{ related.summary }}</p>
+            <small class="text-muted-iih"><i class="bi bi-caret-up-fill"></i> {{ related.votes }}</small>
+          </a>
+          {% endfor %}
+        </div>
+        {% else %}
+        <p class="text-muted-iih mb-0">No similar ideas yet in this category.</p>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -266,7 +266,7 @@
           <span class="tag tag-yellow mb-3">🔥 Trending right now</span>
           <h2 class="mb-0">This week's most-voted ideas</h2>
         </div>
-        <a href="#" class="btn btn-outline-iih">
+        <a href="{{ url_for('main.explore') }}" class="btn btn-outline-iih">
           See all ideas <i class="bi bi-arrow-right"></i>
         </a>
       </div>
@@ -276,7 +276,10 @@
           {% set tag_class_map = {'FinTech':'tag-brand','EdTech':'tag-violet','GreenTech':'tag-mint','DevTools':'tag-dark','Health':'tag-pink','Productivity':'tag-blue','Social':'tag-mint','Creator Economy':'tag-yellow'} %}
           {% for idea in trending_ideas %}
           <div class="col-md-6 col-lg-4" data-scroll-reveal>
-            <a href="#" class="text-decoration-none">
+            <a
+              href="{% if current_user.is_authenticated %}{{ url_for('main.idea_detail', idea_id=idea.id) }}{% else %}{{ url_for('auth.login', next=url_for('main.idea_detail', idea_id=idea.id)) }}{% endif %}"
+              class="text-decoration-none"
+            >
               <div class="idea-card card-iih">
                 <div class="card-body-iih">
                   <div class="d-flex justify-content-between align-items-start mb-3">
@@ -327,7 +330,7 @@
           <!-- Fallback hardcoded cards if DB is empty -->
           <div class="col-12 text-center py-5">
             <p class="text-muted-iih">No ideas yet — be the first to share one!</p>
-            <a href="#" class="btn btn-brand">Share an idea</a>
+            <a href="{{ url_for('main.submit_idea') }}" class="btn btn-brand">Share an idea</a>
           </div>
         {% endif %}
       </div>
@@ -398,7 +401,7 @@
             <p class="mb-0 fs-5" style="color: var(--ink-300);">Join {{ total_users }}+ builders turning late-night ideas into real products. Free forever.</p>
           </div>
           <div class="col-lg-4 text-lg-end">
-            <a href="#" class="btn btn-brand btn-lg-iih">
+            <a href="{{ url_for('auth.register') }}" class="btn btn-brand btn-lg-iih">
               Start shipping <i class="bi bi-rocket-takeoff"></i>
             </a>
           </div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -36,8 +36,11 @@
 
         <!-- Form -->
         <!-- <form method="POST" class="auth-form" novalidate> -->
-        <form method="POST" action="{{ url_for('auth.login') }}" class="auth-form" novalidate>
+        <form method="POST" action="{{ url_for('auth.login', next=next_page) if next_page else url_for('auth.login') }}" class="auth-form" novalidate>
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            {% if next_page %}
+            <input type="hidden" name="next" value="{{ next_page }}">
+            {% endif %}
             <!-- Email -->
             <div class="mb-3">
             <label class="form-label-iih" for="email">Email address</label>


### PR DESCRIPTION
## Summary
- Unify guest/authenticated experience on the same `Explore` page with blur-lock gating and login/register overlay.
- Improve login return behavior (`next` + safe referrer fallback) so users return to the page they came from.
- Fix bookmark UX on idea detail (single reliable handler, server-backed initial state, error-only feedback).
- Enhance idea detail page with:
  - Progress timeline
  - Collaborator needs
  - Related ideas
  - Weekly momentum (7-day votes/comments mini chart)
- Refine sidebar spacing and navbar placement consistency.

## Why
These changes improve page completeness and UX consistency while keeping access control clear for unauthenticated users.

## Test plan
- [ ] As guest, open `/explore` and confirm content is blurred with overlay actions.
- [ ] Login from explore and confirm redirect returns to current page (not dashboard).
- [ ] On idea detail, click bookmark and verify:
  - [ ] state updates correctly
  - [ ] bookmarked ideas appear in profile bookmarks
  - [ ] only failure shows error alert
- [ ] Verify timeline, collaborator-needs, related ideas, and weekly momentum render on idea detail.
- [ ] Verify navbar placement/spacing on guest and authenticated states.