### PR TITLE
fix(collaboration): update sidebar list and count on join/leave witho…

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -959,6 +959,24 @@ def toggle_idea_collaboration(idea_id: int):
         collaborating = True
 
     db.session.commit()
+
+    # Return updated collaborator list so JS can re-render without a refresh
+    collaborators = (
+        Collaboration.query
+        .filter_by(idea_id=idea.id, status="accepted")
+        .join(User, Collaboration.user_id == User.id)
+        .all()
+    )
+    collab_data = [
+        {
+            "name": c.user.display_name,
+            "initials": c.user.initials,
+            "avatar_class": f"avatar-{c.user.avatar_color}",
+            "role": c.role,
+        }
+        for c in collaborators
+    ]
+
     return jsonify(
         {
             "ok": True,
@@ -966,6 +984,7 @@ def toggle_idea_collaboration(idea_id: int):
             "user_id": actor.id,
             "collaborating": collaborating,
             "collaborators_total": idea.collaborator_count,
+            "collaborators": collab_data,
         }
     )
 

--- a/static/js/idea-detail.js
+++ b/static/js/idea-detail.js
@@ -357,6 +357,8 @@ document.addEventListener("DOMContentLoaded", () => {
         if (!response.ok || !payload.ok) {
           throw new Error(payload.error || `Collaborate request failed: ${response.status}`);
         }
+
+        // Update button state
         collaborateBtn.classList.toggle("voted", payload.collaborating);
         const label = collaborateBtn.querySelector("span");
         if (label) {
@@ -364,6 +366,29 @@ document.addEventListener("DOMContentLoaded", () => {
             ? "Joined as collaborator"
             : "Join as collaborator";
         }
+
+        // Update sidebar count heading
+        const countEl = document.querySelector(".sidebar-card .collab-list")
+          ?.closest(".sidebar-card")
+          ?.querySelector(".text-muted-iih.small");
+        if (countEl) {
+          countEl.textContent = `(${payload.collaborators_total})`;
+        }
+
+        // Re-render collaborator list
+        const collabList = document.querySelector(".collab-list");
+        if (collabList && payload.collaborators) {
+          collabList.innerHTML = payload.collaborators
+            .map(
+              (m) => `
+            <div class="collab-item">
+              <span class="avatar avatar-sm ${m.avatar_class}">${m.initials}</span>
+              <div><strong>${m.name}</strong><span>${m.role}</span></div>
+            </div>`
+            )
+            .join("");
+        }
+
       } catch (error) {
         console.error(error);
         showActionFeedback("Unable to update collaboration right now. Please try again.");


### PR DESCRIPTION
The collaborate toggle AJAX handler was only changing the button label. It now receives the full updated collaborator list from the server and re-renders the sidebar .collab-list div and the count heading in place.