### PR TITLE
feat: polish hero layout, button gradients, and marquee banner

### DIFF
--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -6,7 +6,7 @@
 /* ─── HERO ─── */
 .hero {
   position: relative;
-  padding: 5.5rem 0 2rem;
+  padding: 3.5rem 0 16px;
   overflow: hidden;
   background: var(--paper);
   transition: background 0.3s ease;
@@ -142,7 +142,7 @@
   color: var(--ink-600);
   line-height: 1.6;
   max-width: 540px;
-  margin-bottom: 2.2rem;
+  margin-bottom: 1.5rem;
 }
 [data-theme="dark"] .hero-sub { color: var(--ink-600); }
 
@@ -151,7 +151,7 @@
   display: flex;
   gap: 0.85rem;
   flex-wrap: wrap;
-  margin-bottom: 2.2rem;
+  margin-bottom: 1.5rem;
 }
 
 /* ─── HERO SOCIAL PROOF ─── */
@@ -184,22 +184,22 @@
   align-items: center;
   gap: 0.6rem;
   padding: 0.55rem 1rem;
-  background: rgba(255,255,255,0.72);
+  background: linear-gradient(135deg, rgba(255,90,31,0.12) 0%, rgba(91,63,255,0.10) 100%);
   backdrop-filter: blur(12px);
-  border: 1px solid rgba(255,255,255,0.55);
+  border: 1px solid rgba(255,90,31,0.25);
   border-radius: var(--radius-pill);
   font-size: 0.82rem;
   color: var(--ink-700);
   font-weight: 500;
   max-width: 420px;
   overflow: hidden;
-  margin-top: 1.5rem;
-  margin-bottom: 2rem;
+  margin-top: 1rem;
+  margin-bottom: 1.2rem;
   box-shadow: var(--shadow-sm);
 }
 [data-theme="dark"] .hero-live-ticker {
-  background: rgba(26,26,48,0.72);
-  border-color: rgba(255,255,255,0.08);
+  background: linear-gradient(135deg, rgba(255,90,31,0.18) 0%, rgba(91,63,255,0.15) 100%);
+  border-color: rgba(255,90,31,0.30);
   color: var(--ink-700);
 }
 
@@ -413,9 +413,9 @@
 
 /* ─── MARQUEE ─── */
 .marquee-strip {
-  background: var(--ink-900);
+  background: #0B0B12;
   color: white;
-  margin-top: 4.5rem;
+  margin-top: 2.5rem;
   padding: 1.1rem 0;
   overflow: hidden;
   position: relative;
@@ -423,23 +423,8 @@
   margin-left: -3%;
   margin-right: -3%;
   width: 106%;
-  border-top: 2px solid transparent;
-  border-bottom: 2px solid transparent;
-  background-clip: padding-box;
-}
-.marquee-strip::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(90deg,
-    var(--brand-primary) 0%, var(--brand-pink) 25%,
-    var(--brand-secondary) 50%, var(--brand-blue) 75%,
-    var(--brand-accent) 100%);
-  opacity: 0.25;
-  pointer-events: none;
-}
-[data-theme="dark"] .marquee-strip {
-  background: linear-gradient(135deg, #06060F 0%, #0E0E1C 100%);
+  border-top: 2px solid var(--brand-primary);
+  border-bottom: 2px solid var(--brand-primary);
 }
 .marquee-track {
   display: flex;
@@ -1179,7 +1164,7 @@
 
 /* ─── Responsive tweaks ─── */
 @media (max-width: 991px) {
-  .hero           { padding: 3.5rem 0 2rem; }
+  .hero           { padding: 2.5rem 0 0; }
   .hero-card-stack { height: 540px; margin-top: 2rem; }
   .float-card     { width: 280px; }
   .float-card-1   { right: auto; left: 0; }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -342,12 +342,12 @@ a:hover { color: var(--brand-primary-dark); }
   box-shadow: var(--shadow-md);
 }
 .btn-brand {
-  background: var(--brand-primary);
+  background: linear-gradient(135deg, #FF5A1F 0%, #FF4D8F 100%);
   color: white;
-  border-color: var(--brand-primary);
+  border-color: transparent;
 }
 .btn-brand:hover {
-  background: var(--brand-primary-dark);
+  background: linear-gradient(135deg, #e04a12 0%, #e63d7a 100%);
   color: white;
   transform: translateY(-2px) scale(1.02);
   box-shadow: var(--shadow-brand);
@@ -356,13 +356,13 @@ a:hover { color: var(--brand-primary-dark); }
   transform: translateY(1px) scale(0.99);
 }
 .btn-outline-iih {
-  background: var(--paper);
+  background: linear-gradient(135deg, #f5f3ff 0%, #ede9fe 100%);
   color: var(--ink-800);
-  border-color: var(--ink-200);
+  border-color: rgba(91,63,255,0.20);
 }
 .btn-outline-iih:hover {
-  background: var(--ink-50);
-  border-color: var(--ink-300);
+  background: linear-gradient(135deg, #ede9fe 0%, #ddd6fe 100%);
+  border-color: rgba(91,63,255,0.35);
   color: var(--ink-900);
 }
 .btn-ghost {

--- a/static/js/bg-fx.js
+++ b/static/js/bg-fx.js
@@ -78,12 +78,7 @@
       this.r  = tier === 1 ? 4.5 : tier === 2 ? 2.2 : 1.1;
       this.c  = tier === 1 ? C.orange : tier === 2 ? C.violet
                            : (Math.random() < 0.5 ? C.mint : C.blue);
-      /* hub pulse state */
-      this.pulseR     = 0;
-      this.pulseAlpha = 0;
-      this.pulseNext  = 240 + Math.floor(Math.random() * 300);
-      /* flare when a packet arrives */
-      this.flare      = 0;
+      /* (pulse/flare removed — smooth glow only) */
     }
 
     update () {
@@ -101,48 +96,15 @@
       if (this.x > W - m) this.vx -= 0.025;
       if (this.y < m)     this.vy += 0.025;
       if (this.y > H - m) this.vy -= 0.025;
-      /* hub pulse countdown */
-      if (this.tier === 1) {
-        this.pulseNext--;
-        if (this.pulseNext <= 0) {
-          this.pulseR     = 0;
-          this.pulseAlpha = 1;
-          this.pulseNext  = 300 + Math.floor(Math.random() * 360);
-        }
-        if (this.pulseAlpha > 0) {
-          this.pulseR     += 1.2;
-          this.pulseAlpha *= 0.975;
-          if (this.pulseAlpha < 0.01) { this.pulseAlpha = 0; this.pulseR = 0; }
-        }
-      }
-      if (this.flare > 0) this.flare *= 0.88;
     }
 
     draw (alpha, dark) {
       const { r, g, b } = this.c;
 
-      /* hub pulse ring */
-      if (this.tier === 1 && this.pulseAlpha > 0.01) {
-        ctx.beginPath();
-        ctx.arc(this.x, this.y, this.pulseR, 0, Math.PI * 2);
-        ctx.strokeStyle = `rgba(${r},${g},${b},${this.pulseAlpha * alpha * 0.55})`;
-        ctx.lineWidth   = 1.4;
-        ctx.stroke();
-        /* second ring slightly behind */
-        if (this.pulseR > 14) {
-          ctx.beginPath();
-          ctx.arc(this.x, this.y, this.pulseR - 14, 0, Math.PI * 2);
-          ctx.strokeStyle = `rgba(${r},${g},${b},${this.pulseAlpha * alpha * 0.25})`;
-          ctx.lineWidth   = 0.7;
-          ctx.stroke();
-        }
-      }
-
-      /* glow halo — bigger on hub / when flaring */
-      const glowMult = 1 + this.flare * 2.5;
-      const gr       = this.r * (this.tier === 1 ? 9 : this.tier === 2 ? 7 : 5) * glowMult;
-      const grd      = ctx.createRadialGradient(this.x, this.y, 0, this.x, this.y, gr);
-      const coreA    = alpha * (this.tier === 1 ? 0.55 : 0.38) * glowMult;
+      /* smooth glow halo */
+      const gr  = this.r * (this.tier === 1 ? 9 : this.tier === 2 ? 7 : 5);
+      const grd = ctx.createRadialGradient(this.x, this.y, 0, this.x, this.y, gr);
+      const coreA = alpha * (this.tier === 1 ? 0.55 : 0.38);
       grd.addColorStop(0, `rgba(${r},${g},${b},${Math.min(1, coreA)})`);
       grd.addColorStop(1, `rgba(${r},${g},${b},0)`);
       ctx.beginPath();
@@ -152,7 +114,7 @@
 
       /* sharp core dot */
       ctx.beginPath();
-      ctx.arc(this.x, this.y, this.r * glowMult, 0, Math.PI * 2);
+      ctx.arc(this.x, this.y, this.r, 0, Math.PI * 2);
       ctx.fillStyle = `rgba(${r},${g},${b},${Math.min(1, alpha)})`;
       ctx.fill();
     }
@@ -184,7 +146,7 @@
       this.trail.push({ x: p.x, y: p.y });
       if (this.trail.length > 16) this.trail.shift();
       this.t += this.speed;
-      if (this.done) this.b.flare = 1.0;   // flare the destination
+      // arrival — no flare
     }
 
     draw (alpha) {


### PR DESCRIPTION
- Reduce hero top padding (5.5rem → 3.5rem) so marquee banner is visible without scrolling
- Give both CTA buttons gradient backgrounds (brand: orange→pink, outline: lavender→violet)
- Style live-ticker pill with orange→violet gradient tint and border
- Fix marquee banner: solid #0B0B12 bg, visible orange top/bottom borders, remove broken dark-mode gradient override
- Add 16px bottom padding to .hero so -0.8deg rotated marquee isn't clipped by overflow:hidden